### PR TITLE
Add WebGPU typings and canvas check

### DIFF
--- a/src/shared/components/TermsModal.tsx
+++ b/src/shared/components/TermsModal.tsx
@@ -7,7 +7,7 @@ export default function TermsModal({ onAgree }: { onAgree: () => void }) {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas) throw new Error("canvasが見つかりません");
     if (!navigator.gpu) {
       setGpuSupported(false);
       return;

--- a/src/types/webgpu.d.ts
+++ b/src/types/webgpu.d.ts
@@ -1,0 +1,32 @@
+export {};
+
+declare global {
+  interface Navigator {
+    gpu?: GPU;
+  }
+
+  interface GPU {}
+  interface GPUAdapter {
+    requestDevice(descriptor?: GPUDeviceDescriptor): Promise<GPUDevice>;
+  }
+  interface GPUDevice {
+    createBuffer(descriptor: GPUBufferDescriptor): GPUBuffer;
+    createShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule;
+    createRenderPipeline(descriptor: GPURenderPipelineDescriptor): GPURenderPipeline;
+    createBindGroup(descriptor: GPUBindGroupDescriptor): GPUBindGroup;
+    createCommandEncoder(descriptor?: GPUCommandEncoderDescriptor): GPUCommandEncoder;
+    queue: GPUQueue;
+  }
+  interface GPUCanvasContext {
+    configure(config: GPUCanvasConfiguration): void;
+    getCurrentTexture(): GPUTexture;
+  }
+  interface GPUBuffer {}
+  interface GPURenderPipeline {}
+  interface GPUBindGroup {}
+  const GPUBufferUsage: {
+    UNIFORM: number;
+    COPY_DST: number;
+  };
+}
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["./src/types/webgpu"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- add minimal WebGPU type stubs
- configure tsconfig to include the new types
- throw an error when canvas is missing to avoid nullable usage

## Testing
- `tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react')*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e876cac2483258e67edb7375111bd