### PR TITLE
Add fuller WebGPU typings

### DIFF
--- a/src/shared/components/TermsModal.tsx
+++ b/src/shared/components/TermsModal.tsx
@@ -7,15 +7,15 @@ export default function TermsModal({ onAgree }: { onAgree: () => void }) {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas) throw new Error("canvasが見つかりません");
     if (!navigator.gpu) {
       setGpuSupported(false);
       return;
     }
 
     function resizeCanvas() {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+      canvas!.width = window.innerWidth;
+      canvas!.height = window.innerHeight;
     }
     resizeCanvas();
     window.addEventListener("resize", resizeCanvas);
@@ -33,7 +33,7 @@ export default function TermsModal({ onAgree }: { onAgree: () => void }) {
       const adapter = await navigator.gpu!.requestAdapter();
       if (!adapter) return;
       device = await adapter.requestDevice();
-      context = canvas.getContext("webgpu") as GPUCanvasContext;
+      context = canvas.getContext("webgpu")!;
       const format = navigator.gpu!.getPreferredCanvasFormat();
       context.configure({ device, format, alphaMode: "premultiplied" });
 

--- a/src/types/webgpu.d.ts
+++ b/src/types/webgpu.d.ts
@@ -1,0 +1,164 @@
+export {};
+
+declare global {
+  interface Navigator {
+    gpu?: GPU;
+  }
+
+  interface GPU {
+    requestAdapter(options?: GPURequestAdapterOptions): Promise<GPUAdapter | null>;
+    getPreferredCanvasFormat(): GPUTextureFormat;
+  }
+
+  interface GPUAdapter {
+    requestDevice(descriptor?: GPUDeviceDescriptor): Promise<GPUDevice>;
+  }
+
+  interface GPUDevice {
+    createBuffer(descriptor: GPUBufferDescriptor): GPUBuffer;
+    createShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule;
+    createRenderPipeline(descriptor: GPURenderPipelineDescriptor): GPURenderPipeline;
+    createBindGroup(descriptor: GPUBindGroupDescriptor): GPUBindGroup;
+    createCommandEncoder(descriptor?: GPUCommandEncoderDescriptor): GPUCommandEncoder;
+    queue: GPUQueue;
+  }
+
+  interface GPUQueue {
+    writeBuffer(buffer: GPUBuffer, offset: number, data: BufferSource): void;
+    submit(commands: GPUCommandBuffer[]): void;
+  }
+
+  interface GPUCommandEncoder {
+    beginRenderPass(descriptor: GPURenderPassDescriptor): GPURenderPassEncoder;
+    finish(): GPUCommandBuffer;
+  }
+
+  interface GPURenderPassEncoder {
+    setPipeline(pipeline: GPURenderPipeline): void;
+    setBindGroup(index: number, bindGroup: GPUBindGroup): void;
+    draw(vertexCount: number): void;
+    end(): void;
+  }
+
+  interface GPURenderPipeline {
+    getBindGroupLayout(index: number): GPUBindGroupLayout;
+  }
+
+  interface GPUBindGroupLayout {}
+
+  interface GPUCanvasContext {
+    configure(config: GPUCanvasConfiguration): void;
+    getCurrentTexture(): GPUTexture;
+  }
+
+  interface GPUTexture {
+    createView(descriptor?: GPUTextureViewDescriptor): GPUTextureView;
+  }
+
+  interface GPUTextureView {}
+
+  interface GPUShaderModule {}
+
+  interface GPUBuffer {}
+
+  interface GPUBindGroup {}
+
+  interface GPUCommandBuffer {}
+
+  interface GPUCanvasConfiguration {
+    device: GPUDevice;
+    format: GPUTextureFormat;
+    alphaMode?: 'opaque' | 'premultiplied';
+  }
+
+  interface GPURenderPipelineDescriptor {
+    layout?: GPUPipelineLayout | 'auto';
+    vertex: GPUVertexState;
+    fragment?: GPUFragmentState;
+    primitive?: GPUPrimitiveState;
+  }
+
+  interface GPUPipelineLayout {}
+
+  interface GPUVertexState {
+    module: GPUShaderModule;
+    entryPoint: string;
+  }
+
+  interface GPUFragmentState {
+    module: GPUShaderModule;
+    entryPoint: string;
+    targets: GPUColorTargetState[];
+  }
+
+  interface GPUColorTargetState {
+    format: GPUTextureFormat;
+  }
+
+  interface GPUPrimitiveState {
+    topology: GPUPrimitiveTopology;
+  }
+
+  type GPUPrimitiveTopology = 'triangle-list' | 'triangle-strip';
+
+  interface GPUBindGroupDescriptor {
+    layout: GPUBindGroupLayout;
+    entries: GPUBindGroupEntry[];
+  }
+
+  interface GPUBindGroupEntry {
+    binding: number;
+    resource: GPUBindingResource;
+  }
+
+  interface GPUBindingResource {
+    buffer: GPUBuffer;
+  }
+
+  interface GPUBufferDescriptor {
+    size: number;
+    usage: number;
+  }
+
+  interface GPUShaderModuleDescriptor {
+    code: string;
+  }
+
+  interface GPUCommandEncoderDescriptor {}
+
+  interface GPUDeviceDescriptor {}
+
+  interface GPURequestAdapterOptions {}
+
+  interface GPURenderPassDescriptor {
+    colorAttachments: GPURenderPassColorAttachment[];
+  }
+
+  interface GPURenderPassColorAttachment {
+    view: GPUTextureView;
+    clearValue?: GPUColor;
+    loadOp: 'clear' | 'load';
+    storeOp: 'store' | 'discard';
+  }
+
+  interface GPUColor {
+    r: number;
+    g: number;
+    b: number;
+    a: number;
+  }
+
+  type GPUTextureFormat = string;
+
+  interface GPUTextureViewDescriptor {}
+
+  const GPUBufferUsage: {
+    UNIFORM: number;
+    COPY_DST: number;
+  };
+
+  interface HTMLCanvasElement {
+    getContext(contextId: 'webgpu'): GPUCanvasContext | null;
+  }
+}
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,6 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["./src/types/webgpu"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- refine canvas resize logic to assert canvas is present
- remove unsafe cast when getting the WebGPU context
- implement a more complete custom `webgpu.d.ts` with necessary interfaces

## Testing
- `pnpm run build` *(fails: Cannot find module 'react')*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e876cac2483258e67edb7375111bd