### PR TITLE
[WIP]Integrate Supabase for chat storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@supabase/supabase-js": "^2.43.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/features/chat/hooks/useChatHandlers.ts
+++ b/src/features/chat/hooks/useChatHandlers.ts
@@ -108,7 +108,7 @@ export function useChatHandlers({
       system: true,
     };
     setChatLog((prev: Chat[]) => [leaveMsg, ...prev]);
-    saveChatLogs(leaveMsg);
+    await saveChatLogs(leaveMsg);
     channelRef.current?.postMessage({
       type: 'chat',
       chat: leaveMsg,

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -1,20 +1,32 @@
-import { useCallback, useState } from 'react';
-import { loadChatLogs, saveChatLogs, clearChatLogs } from '@features/chat/api/chatApi';
+import { useCallback, useState, useEffect } from 'react';
+import {
+  loadChatLogs,
+  saveChatLogs,
+  clearChatLogs,
+  subscribeChatLogs,
+} from '@features/chat/api/chatApi';
 import type { Chat } from '@features/chat/types';
 
 export function useChatLog() {
-  const [chatLog, setChatLog] = useState<Chat[]>(() => loadChatLogs());
+  const [chatLog, setChatLog] = useState<Chat[]>([]);
 
-  const addChat = useCallback((chat: Chat) => {
-    setChatLog((prev) => {
-      const updated = [chat, ...prev].slice(0, 2000);
-      saveChatLogs(updated);
-      return updated;
+  useEffect(() => {
+    loadChatLogs().then(setChatLog);
+    const channel = subscribeChatLogs((chat) => {
+      setChatLog((prev) => [chat, ...prev].slice(0, 2000));
     });
+    return () => {
+      channel.unsubscribe();
+    };
   }, []);
 
-  const clear = useCallback(() => {
-    clearChatLogs();
+  const addChat = useCallback(async (chat: Chat) => {
+    setChatLog((prev) => [chat, ...prev].slice(0, 2000));
+    await saveChatLogs(chat);
+  }, []);
+
+  const clear = useCallback(async () => {
+    await clearChatLogs();
     setChatLog([]);
   }, []);
 

--- a/src/pages/ChatLogPage.tsx
+++ b/src/pages/ChatLogPage.tsx
@@ -1,26 +1,19 @@
 import { Suspense, useState, useEffect } from 'react';
 import ChatLogList from '@features/chat/components/ChatLogList.lazy';
 import type { Chat } from '@features/chat/types';
-
-const STORAGE_KEY = 'yui_chat_dat';
-
-// ローカルストレージからチャットログを取得
-function loadChatLog(): Chat[] {
-  try {
-    const dat = localStorage.getItem(STORAGE_KEY);
-    return dat ? JSON.parse(dat) : [];
-  } catch {
-    return [];
-  }
-}
+import { loadChatLogs } from '@features/chat/api/chatApi';
 
 export default function ChatLogPage() {
   const [chatLog, setChatLog] = useState<Chat[]>([]);
   const [windowRows, setWindowRows] = useState(50);
 
   useEffect(() => {
-    setChatLog(loadChatLog());
+    loadChatLogs().then(setChatLog);
   }, []);
+
+  const reload = () => {
+    loadChatLogs().then(setChatLog);
+  };
 
   // 参加者表示用（空リストでOK）
   return (
@@ -44,7 +37,7 @@ export default function ChatLogPage() {
             </option>
           ))}
         </select>
-        <button className="ie-btn" onClick={() => setChatLog(loadChatLog())}>
+        <button className="ie-btn" onClick={reload}>
           再読込
         </button>
       </div>

--- a/src/shared/supabaseClient.ts
+++ b/src/shared/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL as string;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(url, anonKey);


### PR DESCRIPTION
## Summary
- switch local chat log storage to Supabase
- implement realtime subscription and Supabase client
- update hooks to work with Supabase
- refresh ChatLogPage using new API
- add `@supabase/supabase-js` dependency

## Testing
- `pnpm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.app.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f214fcbd48325b519b3498eabb366