### PR TITLE
Implement Supabase based chat API

### DIFF
--- a/src/features/chat/hooks/useChatHandlers.ts
+++ b/src/features/chat/hooks/useChatHandlers.ts
@@ -39,7 +39,7 @@ export function useChatHandlers({
             startTransition(() => {
               setChatLog((prev: Chat[]) => {
                 const log = [data.chat, ...prev];
-                saveChatLogs(log);
+                void saveChatLogs(log);
                 return log;
               });
             });
@@ -55,7 +55,7 @@ export function useChatHandlers({
           case 'clear':
             startTransition(() => {
               setChatLog(() => {
-                clearChatLogs();
+                void clearChatLogs();
                 return [];
               });
             });
@@ -85,7 +85,7 @@ export function useChatHandlers({
 
       setChatLog((prev: Chat[]) => {
         const log = [joinMsg, ...prev];
-        saveChatLogs(log);
+        void saveChatLogs(log);
         return log;
       });
       setTimeout(() => {
@@ -114,7 +114,7 @@ export function useChatHandlers({
     };
     setChatLog((prev: Chat[]) => {
       const log = [leaveMsg, ...prev];
-      saveChatLogs(log);
+      void saveChatLogs(log);
       return log;
     });
     channelRef.current?.postMessage({
@@ -140,7 +140,7 @@ export function useChatHandlers({
         startTransition(() => {
           setChatLog((prev: Chat[]) => {
             const log = prev.filter((c: Chat) => !c.message.match(/img/i));
-            saveChatLogs(log);
+            void saveChatLogs(log);
             return log;
           });
         });
@@ -151,7 +151,7 @@ export function useChatHandlers({
       if (msg.trim() === 'clear') {
         startTransition(() => {
           setChatLog(() => {
-            clearChatLogs();
+            void clearChatLogs();
             return [];
           });
         });
@@ -172,7 +172,7 @@ export function useChatHandlers({
         };
         const log = [chat, ...chatLog];
         setChatLog(() => {
-          saveChatLogs(log);
+          void saveChatLogs(log);
           return log;
         });
         channelRef.current?.postMessage({ type: 'chat', chat });
@@ -184,8 +184,8 @@ export function useChatHandlers({
   );
 
   // チャット履歴再読み込み
-  const handleReload = useCallback(() => {
-    const loaded = loadChatLogs();
+  const handleReload = useCallback(async () => {
+    const loaded = await loadChatLogs();
     setChatLog(() => loaded);
   }, [setChatLog]);
 

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -1,20 +1,24 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { loadChatLogs, saveChatLogs, clearChatLogs } from '@features/chat/api/chatApi';
 import type { Chat } from '@features/chat/types';
 
 export function useChatLog() {
-  const [chatLog, setChatLog] = useState<Chat[]>(() => loadChatLogs());
+  const [chatLog, setChatLog] = useState<Chat[]>([]);
+
+  useEffect(() => {
+    loadChatLogs().then((logs) => setChatLog(logs));
+  }, []);
 
   const addChat = useCallback((chat: Chat) => {
     setChatLog((prev) => {
       const updated = [chat, ...prev].slice(0, 2000);
-      saveChatLogs(updated);
+      void saveChatLogs(updated);
       return updated;
     });
   }, []);
 
   const clear = useCallback(() => {
-    clearChatLogs();
+    void clearChatLogs();
     setChatLog([]);
   }, []);
 

--- a/src/pages/ChatLogPage.tsx
+++ b/src/pages/ChatLogPage.tsx
@@ -1,25 +1,16 @@
 import { Suspense, useState, useEffect } from 'react';
 import ChatLogList from '@features/chat/components/ChatLogList.lazy';
 import type { Chat } from '@features/chat/types';
+import { loadChatLogs } from '@features/chat/api/chatApi';
 
-const STORAGE_KEY = 'yui_chat_dat';
 
-// ローカルストレージからチャットログを取得
-function loadChatLog(): Chat[] {
-  try {
-    const dat = localStorage.getItem(STORAGE_KEY);
-    return dat ? JSON.parse(dat) : [];
-  } catch {
-    return [];
-  }
-}
 
 export default function ChatLogPage() {
   const [chatLog, setChatLog] = useState<Chat[]>([]);
   const [windowRows, setWindowRows] = useState(50);
 
   useEffect(() => {
-    setChatLog(loadChatLog());
+    loadChatLogs().then((logs) => setChatLog(logs));
   }, []);
 
   // 参加者表示用（空リストでOK）
@@ -44,7 +35,10 @@ export default function ChatLogPage() {
             </option>
           ))}
         </select>
-        <button className="ie-btn" onClick={() => setChatLog(loadChatLog())}>
+        <button
+          className="ie-btn"
+          onClick={async () => setChatLog(await loadChatLogs())}
+        >
           再読込
         </button>
       </div>


### PR DESCRIPTION
## Summary
- rewrite `chatApi` to store chat messages in Supabase
- load messages from Supabase in `useChatLog`
- send messages to Supabase in chat handlers
- use Supabase when viewing chat log

## Testing
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f214fcbd48325b519b3498eabb366