### PR TITLE
Implement optimistic chat updates

### DIFF
--- a/src/features/chat/components/ChatMessage/ChatMessage.test.tsx
+++ b/src/features/chat/components/ChatMessage/ChatMessage.test.tsx
@@ -15,6 +15,8 @@ describe('ChatMessage', () => {
     message: 'Hello World',
     time: 1680000000000,
     email: 'alice@example.com',
+    ip: 'ip',
+    ua: 'ua',
   };
 
   const chatWithoutEmail: Chat = {
@@ -24,6 +26,19 @@ describe('ChatMessage', () => {
     message: 'Hi there',
     time: 1680000000000,
     email: '',
+    ip: 'ip',
+    ua: 'ua',
+  };
+
+  const sendingChat: Chat = {
+    id: '3',
+    name: 'Carol',
+    color: '#123456',
+    message: 'Pending',
+    time: 1680000000000,
+    ip: 'ip',
+    ua: 'ua',
+    sending: true,
   };
 
   it('renders chat message with email link', () => {
@@ -49,5 +64,11 @@ describe('ChatMessage', () => {
     const gtSymbol = screen.getByText('>', { selector: 'span' });
     expect(gtSymbol).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows sending indicator when sending', () => {
+    render(<ChatMessage chat={sendingChat} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('(Sending...)')).toBeInTheDocument();
   });
 });

--- a/src/features/chat/components/ChatMessage/index.tsx
+++ b/src/features/chat/components/ChatMessage/index.tsx
@@ -26,6 +26,7 @@ export default function ChatMessage({ chat }: Props) {
           <span className="font-bold text-gray-400 px-1">{'>'}</span>
         )}
         <span className="ml-1 text-gray-700">{chat.message}</span>
+        {chat.sending && <small className="text-gray-500"> (Sending...)</small>}
         <span className="ml-2 text-gray-400 text-xs">({formatTime(chat.time)})</span>
       </div>
     </>

--- a/src/features/chat/hooks/useChatLog.test.ts
+++ b/src/features/chat/hooks/useChatLog.test.ts
@@ -13,18 +13,21 @@ vi.mock('@features/chat/api/chatApi', () => ({
   subscribeChatLogs: vi.fn(() => ({ unsubscribe: vi.fn() })),
 }));
 
-describe('useChatLog', () => {  it('should initialize and return expected interface', () => {
+describe('useChatLog', () => {
+  it('should initialize and return expected interface', () => {
     const { result } = renderHook(() => useChatLog());
 
     // フックが期待されるインターフェースを返すことのみをテスト
     expect(result.current).toHaveProperty('chatLog');
     expect(result.current).toHaveProperty('setChatLog');
     expect(result.current).toHaveProperty('addChat');
+    expect(result.current).toHaveProperty('addOptimistic');
     expect(result.current).toHaveProperty('clear');
-    
+
     expect(Array.isArray(result.current.chatLog)).toBe(true);
     expect(typeof result.current.setChatLog).toBe('function');
     expect(typeof result.current.addChat).toBe('function');
+    expect(typeof result.current.addOptimistic).toBe('function');
     expect(typeof result.current.clear).toBe('function');
   });
 });

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useOptimistic, startTransition } from 'react';
 import {
   loadChatLogs,
   saveChatLog,
@@ -9,26 +9,54 @@ import type { Chat } from '@features/chat/types';
 
 export function useChatLog() {
   const [chatLog, setChatLog] = useState<Chat[]>([]);
+  const [optimisticLog, addOptimistic] = useOptimistic(chatLog, (state: Chat[], chat: Chat) => {
+    const index = state.findIndex((c) => c.id === chat.id);
+    if (index !== -1) {
+      const next = [...state];
+      next[index] = chat;
+      return next.slice(0, 2000);
+    }
+    return [chat, ...state].slice(0, 2000);
+  });
 
   useEffect(() => {
     loadChatLogs().then(setChatLog);
     const channel = subscribeChatLogs((chat) => {
-      setChatLog((prev) => [chat, ...prev].slice(0, 2000));
+      setChatLog((prev) => {
+        const idx = prev.findIndex((c) => c.id === chat.id);
+        if (idx !== -1) {
+          const next = [...prev];
+          next[idx] = chat;
+          return next.slice(0, 2000);
+        }
+        return [chat, ...prev].slice(0, 2000);
+      });
     });
     return () => {
       channel.unsubscribe();
     };
   }, []);
 
-  const addChat = useCallback(async (chat: Chat) => {
-    setChatLog((prev) => [chat, ...prev].slice(0, 2000));
-    await saveChatLog(chat);
-  }, []);
+  const addChat = useCallback(
+    async (chat: Chat) => {
+      addOptimistic(chat);
+      startTransition(() => {
+        saveChatLog(chat);
+      });
+    },
+    [addOptimistic]
+  );
 
   const clear = useCallback(async () => {
     await clearChatLogs();
     // Supabaseリアルタイム購読でクリアが反映されるため、ローカル状態は変更しない
   }, []);
 
-  return { chatLog, setChatLog, addChat, clear };
+  return {
+    chatLog: optimisticLog,
+    setChatLog,
+    addChat,
+    addOptimistic,
+    clear,
+  };
 }

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -8,6 +8,7 @@ export type Chat = {
   email?: string;
   ip: string;
   ua: string;
+  sending?: boolean;
 };
 
 export type Participant = {


### PR DESCRIPTION
## Summary
- update chat log hook to use `useOptimistic`
- optimistically add join/leave/send messages before API calls
- adjust components and tests to show sending state

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530f4336388325bc58586eaaee5201