### PR TITLE
Implement optimistic chat updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ export default function App() {
   });
 
   usePageView('ホーム - ゆいちゃっとTS');
-  const { chatLog, setChatLog, addOptimistic } = useChatLog();
+  const { chatLog, setChatLog, addOptimistic, mergeChat } = useChatLog();
   const participants = useParticipants(chatLog);
   const [entered, setEntered] = useState(false);
   const [showTerms, setShowTerms] = useState(() => localStorage.getItem('agreed-terms') !== 'true');
@@ -54,6 +54,7 @@ export default function App() {
     setName,
     setMessage,
     addOptimistic,
+    mergeChat,
   });
 
   return (

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -14,7 +14,18 @@ export async function loadChatLogs(): Promise<Chat[]> {
 }
 
 export async function saveChatLog(chat: Chat): Promise<void> {
-  await supabase.from(TABLE).insert(chat);
+  const sanitized = {
+    id: chat.id,
+    name: chat.name,
+    color: chat.color,
+    message: chat.message,
+    time: chat.time,
+    system: chat.system,
+    email: chat.email,
+    ip: chat.ip,
+    ua: chat.ua,
+  } as Chat;
+  await supabase.from(TABLE).insert(sanitized);
 }
 
 export async function clearChatLogs(): Promise<void> {

--- a/src/features/chat/hooks/useChatLog.test.ts
+++ b/src/features/chat/hooks/useChatLog.test.ts
@@ -13,18 +13,23 @@ vi.mock('@features/chat/api/chatApi', () => ({
   subscribeChatLogs: vi.fn(() => ({ unsubscribe: vi.fn() })),
 }));
 
-describe('useChatLog', () => {  it('should initialize and return expected interface', () => {
+describe('useChatLog', () => {
+  it('should initialize and return expected interface', () => {
     const { result } = renderHook(() => useChatLog());
 
     // フックが期待されるインターフェースを返すことのみをテスト
     expect(result.current).toHaveProperty('chatLog');
     expect(result.current).toHaveProperty('setChatLog');
     expect(result.current).toHaveProperty('addChat');
+    expect(result.current).toHaveProperty('addOptimistic');
+    expect(result.current).toHaveProperty('mergeChat');
     expect(result.current).toHaveProperty('clear');
-    
+
     expect(Array.isArray(result.current.chatLog)).toBe(true);
     expect(typeof result.current.setChatLog).toBe('function');
     expect(typeof result.current.addChat).toBe('function');
+    expect(typeof result.current.addOptimistic).toBe('function');
+    expect(typeof result.current.mergeChat).toBe('function');
     expect(typeof result.current.clear).toBe('function');
   });
 });

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useOptimistic, startTransition } from 'react';
 import {
   loadChatLogs,
   saveChatLog,
@@ -9,26 +9,64 @@ import type { Chat } from '@features/chat/types';
 
 export function useChatLog() {
   const [chatLog, setChatLog] = useState<Chat[]>([]);
+  const mergeChat = useCallback(
+    (chat: Chat) => {
+      setChatLog((prev) => {
+        const idx = prev.findIndex((c) => c.id === chat.id);
+        if (idx !== -1) {
+          const next = [...prev];
+          next[idx] = chat;
+          return next.slice(0, 2000);
+        }
+        return [chat, ...prev].slice(0, 2000);
+      });
+    },
+    [setChatLog]
+  );
+  const [optimisticLog, addOptimistic] = useOptimistic(chatLog, (state: Chat[], chat: Chat) => {
+    const index = state.findIndex((c) => c.id === chat.id);
+    if (index !== -1) {
+      const next = [...state];
+      next[index] = chat;
+      return next.slice(0, 2000);
+    }
+    return [chat, ...state].slice(0, 2000);
+  });
 
   useEffect(() => {
     loadChatLogs().then(setChatLog);
     const channel = subscribeChatLogs((chat) => {
-      setChatLog((prev) => [chat, ...prev].slice(0, 2000));
+      mergeChat(chat);
     });
     return () => {
       channel.unsubscribe();
     };
-  }, []);
+  }, [mergeChat]);
 
-  const addChat = useCallback(async (chat: Chat) => {
-    setChatLog((prev) => [chat, ...prev].slice(0, 2000));
-    await saveChatLog(chat);
-  }, []);
+  const addChat = useCallback(
+    async (chat: Chat) => {
+      startTransition(() => {
+        addOptimistic(chat);
+      });
+      await saveChatLog(chat);
+      startTransition(() => {
+        mergeChat(chat);
+      });
+    },
+    [addOptimistic, mergeChat]
+  );
 
   const clear = useCallback(async () => {
     await clearChatLogs();
     // Supabaseリアルタイム購読でクリアが反映されるため、ローカル状態は変更しない
   }, []);
 
-  return { chatLog, setChatLog, addChat, clear };
+  return {
+    chatLog: optimisticLog,
+    setChatLog,
+    addChat,
+    addOptimistic,
+    mergeChat,
+    clear,
+  };
 }


### PR DESCRIPTION
## Summary
- update chat log hook to use `useOptimistic`
- optimistically add join/leave/send messages before API calls
- adjust App and tests for new API
- apply merge to final chat items after saving
- sanitize chat object before saving to supabase to avoid invalid fields

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68530f4336388325bc58586eaaee5201