### PR TITLE
perf: クライアントIPをセッション1回に削減しアプリ起動時にプリフェッチ

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,8 @@ vi.mock('@features/chat/utils/webAudioPlayer', () => ({
 vi.mock('@shared/utils/clientInfo', () => ({
   getClientIP: vi.fn().mockResolvedValue('127.0.0.1'),
   getUserAgent: vi.fn().mockReturnValue('test-agent'),
+  prefetchClientIP: vi.fn(),
+  resetClientIPCache: vi.fn(),
 }));
 
 beforeEach(() => {

--- a/src/features/chat/components/EntryForm/index.tsx
+++ b/src/features/chat/components/EntryForm/index.tsx
@@ -1,10 +1,11 @@
-import { useId, useState, useEffect } from 'react';
+import { useId, useState, useEffect, useRef } from 'react';
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import Button from '@shared/components/Button';
 import Input from '@shared/components/Input';
 import { useSettings } from '@features/chat/hooks/useSettings';
 import { AVATAR_IDS } from '@features/chat/types';
 import type { AvatarId } from '@features/chat/types';
+import { prefetchClientIP } from '@shared/utils/clientInfo';
 
 type EntryFormProps = {
   name: string;
@@ -45,6 +46,14 @@ export default function EntryForm({
   const { settings, updateSettings } = useSettings();
   const [silent, setSilent] = useState(false);
   const [avatar, setAvatar] = useState<AvatarId>(settings.avatar);
+  const prefetchedRef = useRef(false);
+
+  // 入室フォームへの最初のユーザーインタラクションでクライアントIPを先行取得
+  function triggerPrefetch() {
+    if (prefetchedRef.current) return;
+    prefetchedRef.current = true;
+    prefetchClientIP();
+  }
 
   // localStorage から設定値を復元して親の state を初期化（マウント時1回のみ）
   const [initialized, setInitialized] = useState(false);
@@ -82,7 +91,11 @@ export default function EntryForm({
             value={name}
             maxLength={24}
             size={20}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              triggerPrefetch();
+              setName(e.target.value);
+            }}
+            onFocus={triggerPrefetch}
             required
             autoFocus
             aria-label="おなまえ"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,13 @@ import { createRoot } from 'react-dom/client';
 import './App.css';
 import App from './App';
 import { recordVisitOncePerSession } from '@features/chat/utils/settingsStore';
+import { prefetchClientIP } from '@shared/utils/clientInfo';
 
 // React ライフサイクルの影響を受けない位置で1回だけ呼び出す
 recordVisitOncePerSession();
+
+// クライアントIPを先行取得（入室・発言時の待ち時間を削減）
+prefetchClientIP();
 
 const root = createRoot(document.getElementById('root')!);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,9 @@ import { createRoot } from 'react-dom/client';
 import './App.css';
 import App from './App';
 import { recordVisitOncePerSession } from '@features/chat/utils/settingsStore';
-import { prefetchClientIP } from '@shared/utils/clientInfo';
 
 // React ライフサイクルの影響を受けない位置で1回だけ呼び出す
 recordVisitOncePerSession();
-
-// クライアントIPを先行取得（入室・発言時の待ち時間を削減）
-prefetchClientIP();
 
 const root = createRoot(document.getElementById('root')!);
 

--- a/src/shared/utils/clientInfo.ts
+++ b/src/shared/utils/clientInfo.ts
@@ -1,4 +1,6 @@
-export async function getClientIP(): Promise<string> {
+let cachedIPPromise: Promise<string> | null = null;
+
+async function fetchClientIP(): Promise<string> {
   try {
     // 複数のIPアドレス取得サービスを試す
     const services = [
@@ -15,17 +17,41 @@ export async function getClientIP(): Promise<string> {
         // サービスごとのレスポンス形式に対応
         if (data.ip) return data.ip;
         if (data.origin) return data.origin;
-      } catch (error) {
+      } catch {
         continue;
       }
     }
 
     return 'unknown';
-  } catch (error) {
+  } catch {
     return 'unknown';
   }
 }
 
+/**
+ * クライアントIPを取得する。
+ * セッション中は同じ Promise を返すため、外部サービスへのアクセスは1回のみ。
+ * 取得失敗時もキャッシュされるので、再試行したい場合は resetClientIPCache() を呼ぶ。
+ */
+export function getClientIP(): Promise<string> {
+  if (!cachedIPPromise) {
+    cachedIPPromise = fetchClientIP();
+  }
+  return cachedIPPromise;
+}
+
+/** キャッシュをクリア（テストや再試行用） */
+export function resetClientIPCache(): void {
+  cachedIPPromise = null;
+}
+
 export function getUserAgent(): string {
   return navigator.userAgent || 'unknown';
+}
+
+/** アプリ起動時に呼ぶと、入室前にIPを先行取得しておける */
+export function prefetchClientIP(): void {
+  if (!cachedIPPromise) {
+    cachedIPPromise = fetchClientIP();
+  }
 }

--- a/src/shared/utils/clientInfo.ts
+++ b/src/shared/utils/clientInfo.ts
@@ -1,41 +1,52 @@
 let cachedIPPromise: Promise<string> | null = null;
 
-async function fetchClientIP(): Promise<string> {
+const IP_FETCH_TIMEOUT_MS = 3000;
+const IP_SERVICES = [
+  'https://api.ipify.org?format=json',
+  'https://httpbin.org/ip',
+  'https://jsonip.com',
+];
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    // 複数のIPアドレス取得サービスを試す
-    const services = [
-      'https://api.ipify.org?format=json',
-      'https://httpbin.org/ip',
-      'https://jsonip.com',
-    ];
-
-    for (const service of services) {
-      try {
-        const response = await fetch(service);
-        const data = await response.json();
-
-        // サービスごとのレスポンス形式に対応
-        if (data.ip) return data.ip;
-        if (data.origin) return data.origin;
-      } catch {
-        continue;
-      }
-    }
-
-    return 'unknown';
-  } catch {
-    return 'unknown';
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
   }
+}
+
+async function fetchClientIP(): Promise<string> {
+  for (const service of IP_SERVICES) {
+    try {
+      const response = await fetchWithTimeout(service, IP_FETCH_TIMEOUT_MS);
+      const data = await response.json();
+      if (data.ip) return data.ip;
+      if (data.origin) return data.origin;
+    } catch {
+      // タイムアウト/ネットワークエラーは次のサービスへフォールバック
+      continue;
+    }
+  }
+  return 'unknown';
 }
 
 /**
  * クライアントIPを取得する。
  * セッション中は同じ Promise を返すため、外部サービスへのアクセスは1回のみ。
- * 取得失敗時もキャッシュされるので、再試行したい場合は resetClientIPCache() を呼ぶ。
+ * 'unknown' が返った場合はキャッシュをクリアし、次回呼び出しで再試行する。
  */
 export function getClientIP(): Promise<string> {
   if (!cachedIPPromise) {
-    cachedIPPromise = fetchClientIP();
+    const promise = fetchClientIP();
+    cachedIPPromise = promise;
+    // 失敗（'unknown'）時はキャッシュを破棄して次回再試行できるようにする
+    promise.then((ip) => {
+      if (ip === 'unknown' && cachedIPPromise === promise) {
+        cachedIPPromise = null;
+      }
+    });
   }
   return cachedIPPromise;
 }
@@ -45,13 +56,14 @@ export function resetClientIPCache(): void {
   cachedIPPromise = null;
 }
 
-export function getUserAgent(): string {
-  return navigator.userAgent || 'unknown';
+/**
+ * 入室前にIPを先行取得する（getClientIP に委譲）。
+ * 入室フォーム操作時などユーザーインタラクション発生タイミングで呼ぶ想定。
+ */
+export function prefetchClientIP(): void {
+  void getClientIP();
 }
 
-/** アプリ起動時に呼ぶと、入室前にIPを先行取得しておける */
-export function prefetchClientIP(): void {
-  if (!cachedIPPromise) {
-    cachedIPPromise = fetchClientIP();
-  }
+export function getUserAgent(): string {
+  return navigator.userAgent || 'unknown';
 }


### PR DESCRIPTION
- clientInfo: Promise キャッシュで外部IPサービスへのアクセスを1回だけに
- clientInfo: prefetchClientIP / resetClientIPCache を追加
- main.tsx: アプリ起動時にIPをプリフェッチ（入室・発言の待ち時間を削減）