### PR TITLE
Feature/renew fix

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,25 +188,25 @@ type ChanariRouteMatch =
   | { type: 'redirect'; to: string };
 ```
 
-| パターン                  | 結果                                                |
-| ------------------------- | --------------------------------------------------- |
-| `/`                       | `TopRoute`                                          |
+| パターン                  | 結果                                                 |
+| ------------------------- | ---------------------------------------------------- |
+| `/`                       | `TopRoute`                                           |
 | `/chat`                   | `/chat/superbeginner` へ `replaceState` リダイレクト |
-| `/chat/:roomId` (有効)    | `ChatRoute`                                         |
+| `/chat/:roomId` (有効)    | `ChatRoute`                                          |
 | `/chanari`                | `/chanari/superbeginner` へリダイレクト              |
-| `/chanari/:roomId` (有効) | `ChanariRoute`                                      |
-| 上記以外                  | `NotFoundRoute`                                     |
+| `/chanari/:roomId` (有効) | `ChanariRoute`                                       |
+| 上記以外                  | `NotFoundRoute`                                      |
 
 App.tsx は `popstate` 監視と `redirect` 種別の自動再評価を担当します。各ルートコンポーネントは**静的 import** で読み込まれ（route 単位の `React.lazy` は導入していません）、`ChatLogList` のみ `ChatRoute` 内で `React.lazy` 化されています。
 
 ### 4.3 レイヤー構成
 
-| レイヤー          | 責務                       | 主要ファイル                                                                |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------- |
-| UI コンポーネント | 描画・ユーザー操作         | `features/*/components/`、`shared/components/`                              |
-| カスタムフック    | 状態管理・ビジネスロジック | `features/*/hooks/`、`shared/hooks/`                                        |
+| レイヤー          | 責務                       | 主要ファイル                                                                     |
+| ----------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| UI コンポーネント | 描画・ユーザー操作         | `features/*/components/`、`shared/components/`                                   |
+| カスタムフック    | 状態管理・ビジネスロジック | `features/*/hooks/`、`shared/hooks/`                                             |
 | API 層            | データ取得・永続化・通信   | `features/chat/api/chatLogResource.ts`、`chatApi.ts`、`top/api/roomCountsApi.ts` |
-| Supabase Client   | DB 接続・認証              | `shared/supabaseClient.ts`                                                  |
+| Supabase Client   | DB 接続・認証              | `shared/supabaseClient.ts`                                                       |
 
 ---
 
@@ -311,17 +311,17 @@ fetchRoomParticipantCounts()
 
 外部状態管理ライブラリ（Redux, Zustand 等）は使用せず、React 組み込みの Hooks で完結しています。
 
-| フック                | 用途                                  | React API                                                       |
-| --------------------- | ------------------------------------- | --------------------------------------------------------------- |
-| `useChatLog`          | チャットログ全体の管理 + 楽観的更新   | `useState`, `useOptimistic` (`reduceOptimisticChat`), `useCallback` |
-| `useChatHandlers`     | 入室・退室・送信・リロード            | `useCallback`, `useTransition`                                  |
-| `useParticipants`     | 参加者リスト導出                      | `useDeferredValue` → `useMemo`                                  |
-| `useNowMinute`        | 1 分境界で再評価する現在時刻          | `useState`, `useEffect` (`setTimeout` + `setInterval`)          |
-| `useRoomCounts`       | トップ用ルーム別参加人数              | `useState`, `useEffect`                                         |
-| `useChanariSettings`  | Chanari の設定永続化                  | `useState`, `useEffect` (`localStorage`)                        |
-| `useReloadInterval`   | Chanari のリロード間隔タイマー        | `useEffect`                                                     |
-| `useSEO`              | メタデータ管理                        | `useEffect`                                                     |
-| `useBroadcastChannel` | クロスタブ通信                        | `useRef`, `useEffect`                                           |
+| フック                | 用途                                | React API                                                           |
+| --------------------- | ----------------------------------- | ------------------------------------------------------------------- |
+| `useChatLog`          | チャットログ全体の管理 + 楽観的更新 | `useState`, `useOptimistic` (`reduceOptimisticChat`), `useCallback` |
+| `useChatHandlers`     | 入室・退室・送信・リロード          | `useCallback`, `useTransition`                                      |
+| `useParticipants`     | 参加者リスト導出                    | `useDeferredValue` → `useMemo`                                      |
+| `useNowMinute`        | 1 分境界で再評価する現在時刻        | `useState`, `useEffect` (`setTimeout` + `setInterval`)              |
+| `useRoomCounts`       | トップ用ルーム別参加人数            | `useState`, `useEffect`                                             |
+| `useChanariSettings`  | Chanari の設定永続化                | `useState`, `useEffect` (`localStorage`)                            |
+| `useReloadInterval`   | Chanari のリロード間隔タイマー      | `useEffect`                                                         |
+| `useSEO`              | メタデータ管理                      | `useEffect`                                                         |
+| `useBroadcastChannel` | クロスタブ通信                      | `useRef`, `useEffect`                                               |
 
 ### 6.2 useChatLog の内部構造
 
@@ -372,18 +372,18 @@ const mergeChat = useCallback((chat: Chat) => {
 
 ### 7.1 chatLogResource.ts（取得・キャッシュ・dedupe の集約）
 
-| エクスポート                              | 用途                                          |
-| ----------------------------------------- | --------------------------------------------- |
-| `loadChatLogs(roomId, useCache?)`         | canonical snapshot（最大 100 件）             |
+| エクスポート                                               | 用途                                                       |
+| ---------------------------------------------------------- | ---------------------------------------------------------- |
+| `loadChatLogs(roomId, useCache?)`                          | canonical snapshot（最大 100 件）                          |
 | `loadChatLogsWithPaging(roomId, offset, limit, useCache?)` | `offset===0` は snapshot を slice。`offset>0` は独立クエリ |
-| `loadInitialChatLogs(roomId, limit?)`     | `loadChatLogsWithPaging(_, 0, limit)` のエイリアス |
-| `prefetchChatLogs(roomId)`                | 結果を捨てつつキャッシュ充填する best-effort  |
-| `invalidateCache(roomId?)`                | room 指定 or 全体クリア、in-flight も解除     |
-| `applyOptimisticToCache(roomId, chat)`    | 楽観的 chat をキャッシュ先頭に挿入            |
-| `replaceOptimisticInCache(tempUuid, serverChat)` | temp 行を server chat で置換           |
-| `getCacheInfo(roomId?)`                   | キャッシュ有無 / age を返す                   |
-| `getPagingHasMore(roomId, offset, limit)` | 直近の paging クエリの `count` 由来判定       |
-| `chatLogResource`                         | 上記をまとめたオブジェクト                    |
+| `loadInitialChatLogs(roomId, limit?)`                      | `loadChatLogsWithPaging(_, 0, limit)` のエイリアス         |
+| `prefetchChatLogs(roomId)`                                 | 結果を捨てつつキャッシュ充填する best-effort               |
+| `invalidateCache(roomId?)`                                 | room 指定 or 全体クリア、in-flight も解除                  |
+| `applyOptimisticToCache(roomId, chat)`                     | 楽観的 chat をキャッシュ先頭に挿入                         |
+| `replaceOptimisticInCache(tempUuid, serverChat)`           | temp 行を server chat で置換                               |
+| `getCacheInfo(roomId?)`                                    | キャッシュ有無 / age を返す                                |
+| `getPagingHasMore(roomId, offset, limit)`                  | 直近の paging クエリの `count` 由来判定                    |
+| `chatLogResource`                                          | 上記をまとめたオブジェクト                                 |
 
 主要な内部状態:
 
@@ -408,16 +408,16 @@ const mergeChat = useCallback((chat: Chat) => {
 
 `loadChatLogs` / `loadChatLogsWithPaging` / `loadInitialChatLogs` / `invalidateCache` / `getCacheInfo` / `prefetchChatLogs` は `chatLogResource` への薄いラッパーとして再 export されています。書き込み系・Realtime 系は引き続き `chatApi.ts` に存在します。
 
-| 関数                         | 用途                     | 特徴                                                       |
-| ---------------------------- | ------------------------ | ---------------------------------------------------------- |
-| `saveChatLogOptimistic()`    | 楽観的更新用保存         | `select('uuid,room_id,time')` で最小応答 + 非同期 invalidate |
-| `saveChatLog()`              | 従来互換の保存           | 全カラム select                                            |
-| `saveChatLogFireAndForget()` | 非ブロッキング保存       | レスポンス不要の最高速版                                   |
-| `clearChatLogs(roomId)`      | room 単位の全件削除      | room を絞ってキャッシュ無効化                              |
-| `clearChatLogsByName()`      | 指定ユーザーの論理削除   | `deleted=true` UPDATE                                      |
-| `loadChatLogsByTimeRange()`  | 時間範囲検索             | UUID v7 範囲クエリ最適化                                   |
-| `subscribeChatLogs()`        | リアルタイム購読         | room ごとに 1 channel を共有                               |
-| `broadcastLookEvent()` 等    | look/unlook 通知の同報   | Realtime broadcast チャネルを再利用                        |
+| 関数                         | 用途                   | 特徴                                                         |
+| ---------------------------- | ---------------------- | ------------------------------------------------------------ |
+| `saveChatLogOptimistic()`    | 楽観的更新用保存       | `select('uuid,room_id,time')` で最小応答 + 非同期 invalidate |
+| `saveChatLog()`              | 従来互換の保存         | 全カラム select                                              |
+| `saveChatLogFireAndForget()` | 非ブロッキング保存     | レスポンス不要の最高速版                                     |
+| `clearChatLogs(roomId)`      | room 単位の全件削除    | room を絞ってキャッシュ無効化                                |
+| `clearChatLogsByName()`      | 指定ユーザーの論理削除 | `deleted=true` UPDATE                                        |
+| `loadChatLogsByTimeRange()`  | 時間範囲検索           | UUID v7 範囲クエリ最適化                                     |
+| `subscribeChatLogs()`        | リアルタイム購読       | room ごとに 1 channel を共有                                 |
+| `broadcastLookEvent()` 等    | look/unlook 通知の同報 | Realtime broadcast チャネルを再利用                          |
 
 ### 7.3 features/top/api/roomCountsApi.ts
 
@@ -431,18 +431,18 @@ const mergeChat = useCallback((chat: Chat) => {
 
 ```typescript
 type Chat = {
-  uuid: string;            // UUID v7（サーバー側で自動生成、主キー）
-  room_id?: RoomId;        // 部屋ごとのログ分離（旧データ互換のため optional）
+  uuid: string; // UUID v7（サーバー側で自動生成、主キー）
+  room_id?: RoomId; // 部屋ごとのログ分離（旧データ互換のため optional）
   name: string;
   color: string;
   message: string;
-  time: number;            // Unix timestamp ms（サーバー側で設定）
-  client_time?: number;    // クライアント投稿時刻（楽観的更新の dedup キー）
-  optimistic?: boolean;    // 楽観的更新フラグ
-  system?: boolean;        // システムメッセージフラグ
+  time: number; // Unix timestamp ms（サーバー側で設定）
+  client_time?: number; // クライアント投稿時刻（楽観的更新の dedup キー）
+  optimistic?: boolean; // 楽観的更新フラグ
+  system?: boolean; // システムメッセージフラグ
   email?: string;
-  ip: string;              // クライアント IP（読み出し時は通常 SELECT しない）
-  ua: string;              // User-Agent（同上）
+  ip: string; // クライアント IP（読み出し時は通常 SELECT しない）
+  ua: string; // User-Agent（同上）
   metadata?: ChatMetadata; // フォントスタイル / アバター / kind / userColor 等
 };
 ```
@@ -495,12 +495,12 @@ type Chat = {
 
 ```css
 /* src/styles/theme.css */
---color-yui-green: #a1fe9f;       /* メイン背景色 */
---color-yui-pink: #ff69b4;        /* アクセントカラー */
---color-yui-pink-light: #ffe4ef;  /* ライトピンク */
---color-ie-gray: #b1b1b1;         /* IE 風グレー */
---color-ie-blue: #4a90e2;         /* IE 風ブルー */
---color-ie-bg: #f3f3f3;           /* IE 風背景 */
+--color-yui-green: #a1fe9f; /* メイン背景色 */
+--color-yui-pink: #ff69b4; /* アクセントカラー */
+--color-yui-pink-light: #ffe4ef; /* ライトピンク */
+--color-ie-gray: #b1b1b1; /* IE 風グレー */
+--color-ie-blue: #4a90e2; /* IE 風ブルー */
+--color-ie-bg: #f3f3f3; /* IE 風背景 */
 
 --font-yui: 'Zen Maru Gothic', 'MS UI Gothic', Arial, sans-serif;
 ```
@@ -509,17 +509,17 @@ type Chat = {
 
 ### 9.2 主要コンポーネント
 
-| コンポーネント                  | 責務                                                            |
-| ------------------------------- | --------------------------------------------------------------- |
-| `RetroSplitter`                 | 上下ペインのリサイズ可能な分割レイアウト                        |
-| `ChatRoom`                      | メッセージ入力・送信・退室ボタン                                |
-| `EntryForm`                     | 名前・色・メール入力、入室ボタン                                |
+| コンポーネント                  | 責務                                                                      |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `RetroSplitter`                 | 上下ペインのリサイズ可能な分割レイアウト                                  |
+| `ChatRoom`                      | メッセージ入力・送信・退室ボタン                                          |
+| `EntryForm`                     | 名前・色・メール入力、入室ボタン                                          |
 | `ChatLogList` (memo + lazy)     | メッセージ履歴の表示。`useMemo` で slice、内部で `useParticipants` を呼ぶ |
-| `ChatMessage` (memo)            | 個別メッセージの描画（管理人 / 通常 / URL リンク化）            |
-| `ChatRanking`                   | 発言数ランキング表示                                            |
-| `ParticipantsList`              | 直近 5 分以内の参加者一覧。`useNowMinute()` を内製              |
-| `TopPage` + `components/header` | 旧ヘッダー（テキスト + CSS）、左カラムのルームリンク群          |
-| `ChanariChatPage` + 関連部品    | Chanari 用 UI、名前色 / 発言色 / 文字数カウンタ / リロード間隔  |
+| `ChatMessage` (memo)            | 個別メッセージの描画（管理人 / 通常 / URL リンク化）                      |
+| `ChatRanking`                   | 発言数ランキング表示                                                      |
+| `ParticipantsList`              | 直近 5 分以内の参加者一覧。`useNowMinute()` を内製                        |
+| `TopPage` + `components/header` | 旧ヘッダー（テキスト + CSS）、左カラムのルームリンク群                    |
+| `ChanariChatPage` + 関連部品    | Chanari 用 UI、名前色 / 発言色 / 文字数カウンタ / リロード間隔            |
 
 ### 9.3 トップページ
 
@@ -545,29 +545,29 @@ type Chat = {
 
 ### 10.1 ビルド最適化
 
-| 最適化       | 設定                                                              |
-| ------------ | ----------------------------------------------------------------- |
+| 最適化       | 設定                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------- |
 | コード分割   | Vite の `manualChunks` で vendor 分離（`vendor-react`, `vendor-supabase`, `vendor-<name>`） |
-| Tree Shaking | Rollup `treeshake: 'recommended'`                                 |
-| 圧縮         | Terser（`console.log` 削除、変数名短縮）                          |
-| CSS 圧縮     | Lightning CSS                                                     |
-| ターゲット   | ES2022                                                            |
+| Tree Shaking | Rollup `treeshake: 'recommended'`                                                           |
+| 圧縮         | Terser（`console.log` 削除、変数名短縮）                                                    |
+| CSS 圧縮     | Lightning CSS                                                                               |
+| ターゲット   | ES2022                                                                                      |
 
 ### 10.2 ランタイム最適化
 
-| 最適化                           | 実装                                                                     |
-| -------------------------------- | ------------------------------------------------------------------------ |
-| 遅延読み込み                     | `ChatLogList` を `React.lazy()` で分割（route 単位の lazy は未導入）     |
-| 楽観的更新                       | `useOptimistic` + `reduceOptimisticChat` で即時反映 + 重複表示防止       |
-| トランジション                   | `useTransition` / `startTransition` で低優先度更新                       |
-| 派生値のメモ化                   | `ChatLogList` / `ChatMessage` を `React.memo`、`chats = useMemo(...)`    |
-| `useParticipants`                | `useDeferredValue(chatLog)` の出力を `useMemo` に通し、再計算を抑制      |
-| 時刻更新の節約                   | `useNowMinute` で 1 分境界まで `setTimeout` → 以降 60s `setInterval`     |
-| API 取得 dedupe                  | `chatLogResource` の `snapshotInflight` / `pagingInflight`               |
-| キャッシュ                       | room 単位 5 分 TTL、保存時に 100 件へ trim、世代カウンタで競合書き戻し抑止 |
-| Supabase 帯域削減                | 取得 SELECT から `ip` / `ua` を除外、書き込みは `select('uuid,room_id,time')` のみ |
-| Realtime チャネル共有            | room ごとに 1 channel を再利用、look broadcast も同 channel に相乗り     |
-| パフォーマンス監視               | 3 秒超の API 呼び出しを `console.warn`                                   |
+| 最適化                | 実装                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| 遅延読み込み          | `ChatLogList` を `React.lazy()` で分割（route 単位の lazy は未導入）               |
+| 楽観的更新            | `useOptimistic` + `reduceOptimisticChat` で即時反映 + 重複表示防止                 |
+| トランジション        | `useTransition` / `startTransition` で低優先度更新                                 |
+| 派生値のメモ化        | `ChatLogList` / `ChatMessage` を `React.memo`、`chats = useMemo(...)`              |
+| `useParticipants`     | `useDeferredValue(chatLog)` の出力を `useMemo` に通し、再計算を抑制                |
+| 時刻更新の節約        | `useNowMinute` で 1 分境界まで `setTimeout` → 以降 60s `setInterval`               |
+| API 取得 dedupe       | `chatLogResource` の `snapshotInflight` / `pagingInflight`                         |
+| キャッシュ            | room 単位 5 分 TTL、保存時に 100 件へ trim、世代カウンタで競合書き戻し抑止         |
+| Supabase 帯域削減     | 取得 SELECT から `ip` / `ua` を除外、書き込みは `select('uuid,room_id,time')` のみ |
+| Realtime チャネル共有 | room ごとに 1 channel を再利用、look broadcast も同 channel に相乗り               |
+| パフォーマンス監視    | 3 秒超の API 呼び出しを `console.warn`                                             |
 
 ---
 
@@ -664,7 +664,7 @@ jobs:
     - actions/setup-node@v3  (node 18)
     - npm install -g pnpm
     - pnpm install
-    - pnpm test               # continue-on-error: true
+    - pnpm test # continue-on-error: true
 ```
 
 `.github/workflows/chromatic.yml` — Storybook ビジュアルリグレッション
@@ -733,12 +733,12 @@ VITE_SUPABASE_ANON_KEY=public-anon-key
 
 ### 15.3 コード品質ツール
 
-| ツール     | 設定ファイル        | 主な設定                                                |
-| ---------- | ------------------- | ------------------------------------------------------- |
+| ツール     | 設定ファイル        | 主な設定                                                                          |
+| ---------- | ------------------- | --------------------------------------------------------------------------------- |
 | ESLint     | `eslint.config.js`  | React Hooks, React Refresh, Prettier 連携、`.kiro` 等を ignore、Markdown は対象外 |
-| Prettier   | `.prettierrc`       | シングルクォート、100 文字幅、セミコロンあり            |
-| TypeScript | `tsconfig.app.json` | strict モード、パスエイリアス                           |
-| Lefthook   | `lefthook.yml`      | Git フック（コミット前チェック）                        |
+| Prettier   | `.prettierrc`       | シングルクォート、100 文字幅、セミコロンあり                                      |
+| TypeScript | `tsconfig.app.json` | strict モード、パスエイリアス                                                     |
+| Lefthook   | `lefthook.yml`      | Git フック（コミット前チェック）                                                  |
 
 ### 15.4 パスエイリアス
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -257,7 +257,7 @@ mergeChat(newChat)
     └─ 新規 → 先頭に追加（最大 2000 件保持）
 ```
 
-`chatApi.ts` 内で `broadcastChannels` / `lookCallbacks` を room 単位の Map で持ち、複数の購読者が同一 channel を共有します。
+`chatApi.ts` 内に `postgresEntries` (`chats-postgres-${roomId}`) と `broadcastEntries` (`chats-broadcast-${roomId}`) の refcount registry を持ち、Postgres Changes と Broadcast はそれぞれ room ごとに 1 channel を共有します。最後の listener が解除された時点で `supabase.removeChannel` で破棄され、send-only 利用（listener 0 での `broadcastLookEvent` / `broadcastUnlookEvent`）も送信完了後に同様に破棄されます。
 
 ### 5.3 初期読み込みフロー
 
@@ -372,18 +372,20 @@ const mergeChat = useCallback((chat: Chat) => {
 
 ### 7.1 chatLogResource.ts（取得・キャッシュ・dedupe の集約）
 
-| エクスポート                                               | 用途                                                       |
-| ---------------------------------------------------------- | ---------------------------------------------------------- |
-| `loadChatLogs(roomId, useCache?)`                          | canonical snapshot（最大 100 件）                          |
-| `loadChatLogsWithPaging(roomId, offset, limit, useCache?)` | `offset===0` は snapshot を slice。`offset>0` は独立クエリ |
-| `loadInitialChatLogs(roomId, limit?)`                      | `loadChatLogsWithPaging(_, 0, limit)` のエイリアス         |
-| `prefetchChatLogs(roomId)`                                 | 結果を捨てつつキャッシュ充填する best-effort               |
-| `invalidateCache(roomId?)`                                 | room 指定 or 全体クリア、in-flight も解除                  |
-| `applyOptimisticToCache(roomId, chat)`                     | 楽観的 chat をキャッシュ先頭に挿入                         |
-| `replaceOptimisticInCache(tempUuid, serverChat)`           | temp 行を server chat で置換                               |
-| `getCacheInfo(roomId?)`                                    | キャッシュ有無 / age を返す                                |
-| `getPagingHasMore(roomId, offset, limit)`                  | 直近の paging クエリの `count` 由来判定                    |
-| `chatLogResource`                                          | 上記をまとめたオブジェクト                                 |
+| エクスポート                                               | 用途                                                                                |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `loadChatLogsSnapshot(roomId, useCache?)`                  | canonical snapshot を `{ data, hasMore }` shape で取得（取得結果に hasMore を同梱） |
+| `loadChatLogs(roomId, useCache?)`                          | `loadChatLogsSnapshot` の `data` のみを返す後方互換 API                             |
+| `loadChatLogsWithPaging(roomId, offset, limit, useCache?)` | `offset===0` は snapshot を slice。`offset>0` は独立クエリ                          |
+| `loadInitialChatLogs(roomId, limit?)`                      | `loadChatLogsWithPaging(_, 0, limit)` のエイリアス                                  |
+| `prefetchChatLogs(roomId)`                                 | 結果を捨てつつキャッシュ充填する best-effort                                        |
+| `invalidateCache(roomId?)`                                 | room 指定 or 全体クリア、in-flight も解除                                           |
+| `applyOptimisticToCache(roomId, chat)`                     | 楽観的 chat をキャッシュ先頭に挿入                                                  |
+| `replaceOptimisticInCache(tempUuid, serverChat)`           | temp 行を server chat で置換                                                        |
+| `getCacheInfo(roomId?)`                                    | キャッシュ有無 / age を返す                                                         |
+| `getPagingHasMore(roomId, offset, limit)`                  | 直近の paging クエリの `count` 由来判定                                             |
+| `getSnapshotHasMore(roomId)`                               | 観測用: 直近 snapshot 取得時の hasMore（未取得 / オフライン中は undefined）         |
+| `chatLogResource`                                          | 上記をまとめたオブジェクト                                                          |
 
 主要な内部状態:
 
@@ -406,7 +408,7 @@ const mergeChat = useCallback((chat: Chat) => {
 
 ### 7.2 chatApi.ts（書き込み / Realtime / 互換ラッパー）
 
-`loadChatLogs` / `loadChatLogsWithPaging` / `loadInitialChatLogs` / `invalidateCache` / `getCacheInfo` / `prefetchChatLogs` は `chatLogResource` への薄いラッパーとして再 export されています。書き込み系・Realtime 系は引き続き `chatApi.ts` に存在します。
+`loadChatLogs` / `loadChatLogsWithPaging` / `loadInitialChatLogs` / `invalidateCache` / `getCacheInfo` / `prefetchChatLogs` / `getSnapshotHasMore` は `chatLogResource` への薄いラッパーとして再 export されています。書き込み系・Realtime 系は引き続き `chatApi.ts` に存在します。`loadChatLogsWithPaging(offset===0)` は `loadChatLogsSnapshot` を直接呼び、`hasMore` を **取得結果と同じ往復で確定した値** から組み立てるため、取得中に `invalidateCache` が走って generation が更新されても hasMore がロストしません。
 
 | 関数                         | 用途                   | 特徴                                                                              |
 | ---------------------------- | ---------------------- | --------------------------------------------------------------------------------- |
@@ -568,7 +570,7 @@ type Chat = {
 | API 取得 dedupe       | `chatLogResource` の `snapshotInflight` / `pagingInflight`                         |
 | キャッシュ            | room 単位 5 分 TTL、保存時に 100 件へ trim、世代カウンタで競合書き戻し抑止         |
 | Supabase 帯域削減     | 取得 SELECT から `ip` / `ua` を除外、書き込みは `select('uuid,room_id,time')` のみ |
-| Realtime チャネル共有 | room ごとに 1 channel を再利用、look broadcast も同 channel に相乗り               |
+| Realtime チャネル共有 | Postgres Changes / Broadcast はそれぞれ room ごとに 1 channel を共有 (`postgresEntries` / `broadcastEntries` refcount registry) |
 | パフォーマンス監視    | 3 秒超の API 呼び出しを `console.warn`                                             |
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,16 +408,16 @@ const mergeChat = useCallback((chat: Chat) => {
 
 `loadChatLogs` / `loadChatLogsWithPaging` / `loadInitialChatLogs` / `invalidateCache` / `getCacheInfo` / `prefetchChatLogs` は `chatLogResource` への薄いラッパーとして再 export されています。書き込み系・Realtime 系は引き続き `chatApi.ts` に存在します。
 
-| 関数                         | 用途                   | 特徴                                                         |
-| ---------------------------- | ---------------------- | ------------------------------------------------------------ |
-| `saveChatLogOptimistic()`    | 楽観的更新用保存       | `select('uuid,room_id,time')` で最小応答 + 非同期 invalidate |
-| `saveChatLog()`              | 従来互換の保存         | 全カラム select                                              |
-| `saveChatLogFireAndForget()` | 非ブロッキング保存     | レスポンス不要の最高速版                                     |
-| `clearChatLogs(roomId)`      | room 単位の全件削除    | room を絞ってキャッシュ無効化                                |
-| `clearChatLogsByName()`      | 指定ユーザーの論理削除 | `deleted=true` UPDATE                                        |
-| `loadChatLogsByTimeRange()`  | 時間範囲検索           | UUID v7 範囲クエリ最適化                                     |
-| `subscribeChatLogs()`        | リアルタイム購読       | room ごとに 1 channel を共有                                 |
-| `broadcastLookEvent()` 等    | look/unlook 通知の同報 | Realtime broadcast チャネルを再利用                          |
+| 関数                         | 用途                   | 特徴                                                                              |
+| ---------------------------- | ---------------------- | --------------------------------------------------------------------------------- |
+| `saveChatLogOptimistic()`    | 楽観的更新用保存       | `select('uuid,room_id,time')` で最小応答 + 非同期 invalidate                      |
+| `saveChatLog()`              | 従来互換の保存         | 全カラム select                                                                   |
+| `saveChatLogFireAndForget()` | 非ブロッキング保存     | レスポンス不要の最高速版                                                          |
+| `clearChatLogs(roomId)`      | room 単位の論理削除    | `update({ deleted: true })` で SELECT 側 `.eq('deleted', false)` と整合、復旧可能 |
+| `clearChatLogsByName()`      | 指定ユーザーの論理削除 | `update({ deleted: true })`                                                       |
+| `loadChatLogsByTimeRange()`  | 時間範囲検索           | UUID v7 範囲クエリ最適化                                                          |
+| `subscribeChatLogs()`        | リアルタイム購読       | room ごとに 1 channel を共有                                                      |
+| `broadcastLookEvent()` 等    | look/unlook 通知の同報 | Realtime broadcast チャネルを再利用                                               |
 
 ### 7.3 features/top/api/roomCountsApi.ts
 
@@ -437,15 +437,17 @@ type Chat = {
   color: string;
   message: string;
   time: number; // Unix timestamp ms（サーバー側で設定）
-  client_time?: number; // クライアント投稿時刻（楽観的更新の dedup キー）
+  client_time?: number; // クライアント投稿時刻（楽観的更新 dedup の fallback キー）
   optimistic?: boolean; // 楽観的更新フラグ
   system?: boolean; // システムメッセージフラグ
   email?: string;
   ip: string; // クライアント IP（読み出し時は通常 SELECT しない）
   ua: string; // User-Agent（同上）
-  metadata?: ChatMetadata; // フォントスタイル / アバター / kind / userColor 等
+  metadata?: ChatMetadata; // フォントスタイル / アバター / kind / userColor / optimisticNonce 等
 };
 ```
+
+楽観的更新の dedup 主キーは `metadata.optimisticNonce`（`createOptimisticChat` がランダム生成）で、両側に nonce が揃っていればこちらだけで一致判定する。`client_time` は nonce 未付与の旧データへの fallback キーとして使うが、両側で数値であることを必須条件とする（`undefined === undefined` の誤一致を避けるため）。
 
 `ChatMetadata.kind = 'admin'` の管理人発言には `userColor` を持たせ、Welcome / 退室メッセージを `ParticipantsList` への参加者集計に用います（`useParticipants.getRecentParticipants` 参照）。
 
@@ -509,17 +511,17 @@ type Chat = {
 
 ### 9.2 主要コンポーネント
 
-| コンポーネント                  | 責務                                                                      |
-| ------------------------------- | ------------------------------------------------------------------------- |
-| `RetroSplitter`                 | 上下ペインのリサイズ可能な分割レイアウト                                  |
-| `ChatRoom`                      | メッセージ入力・送信・退室ボタン                                          |
-| `EntryForm`                     | 名前・色・メール入力、入室ボタン                                          |
-| `ChatLogList` (memo + lazy)     | メッセージ履歴の表示。`useMemo` で slice、内部で `useParticipants` を呼ぶ |
-| `ChatMessage` (memo)            | 個別メッセージの描画（管理人 / 通常 / URL リンク化）                      |
-| `ChatRanking`                   | 発言数ランキング表示                                                      |
-| `ParticipantsList`              | 直近 5 分以内の参加者一覧。`useNowMinute()` を内製                        |
-| `TopPage` + `components/header` | 旧ヘッダー（テキスト + CSS）、左カラムのルームリンク群                    |
-| `ChanariChatPage` + 関連部品    | Chanari 用 UI、名前色 / 発言色 / 文字数カウンタ / リロード間隔            |
+| コンポーネント                  | 責務                                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `RetroSplitter`                 | 上下ペインのリサイズ可能な分割レイアウト                                                                                      |
+| `ChatRoom`                      | メッセージ入力・送信・退室ボタン                                                                                              |
+| `EntryForm`                     | 名前・色・メール入力、入室ボタン                                                                                              |
+| `ChatLogList` (memo + lazy)     | メッセージ履歴の表示。`useMemo` で `sortChatsByTime`（uuid v7 降順）→ `slice(0, windowRows)`、内部で `useParticipants` を呼ぶ |
+| `ChatMessage` (memo)            | 個別メッセージの描画（管理人 / 通常 / URL リンク化）                                                                          |
+| `ChatRanking`                   | 発言数ランキング表示                                                                                                          |
+| `ParticipantsList`              | 直近 5 分以内の参加者一覧。`useNowMinute()` を内製                                                                            |
+| `TopPage` + `components/header` | 旧ヘッダー（テキスト + CSS）、左カラムのルームリンク群                                                                        |
+| `ChanariChatPage` + 関連部品    | Chanari 用 UI、名前色 / 発言色 / 文字数カウンタ / リロード間隔                                                                |
 
 ### 9.3 トップページ
 

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -100,7 +100,7 @@ src/features/chat/api/
 | キャッシュは `MAX_CHAT_LOG = 100` 件に trim される                      | 同上                                               |
 | `useOptimistic` の reducer が temp と saved の重複を抑制する            | `useChatLog.test.ts`                               |
 | `useParticipants` は同一 `chatLog` 参照では再計算しない                 | `useParticipants.test.ts`                          |
-| `ChatLogList` は同一 `chatLog` 参照では `slice` を再実行しない          | `ChatLogList.test.tsx`                             |
+| `ChatLogList` は同一 `chatLog` 参照では `sort/slice` を再実行しない     | `ChatLogList.test.tsx`                             |
 | `useNowMinute` は 1 分境界で更新される                                  | `useNowMinute.test.ts`                             |
 | `/chat/:roomId` / `/chanari/:roomId` / unknown が正しく解決される       | `routing.test.ts` / `chanari-chat/routing.test.ts` |
 | 各ルートが即時描画される（ローディング fallback を挟まない）            | `App.test.tsx`                                     |

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -10,16 +10,16 @@
 
 ## 2. テストの種類と方針
 
-| 種別                | ファイル例                                           | 主なカバー範囲                                           |
-| ------------------- | ---------------------------------------------------- | -------------------------------------------------------- |
-| ユニット            | `*.test.ts`                                          | 純関数 / ユーティリティ（例: `format.test.ts`, `countChars.test.ts`） |
-| コンポーネント      | `*.test.tsx`                                         | React 部品の描画や UI 操作（例: `ChatLogList.test.tsx`） |
-| カスタムフック      | `*.test.ts`                                          | `useChatLog` / `useNowMinute` / `useParticipants` 等     |
-| API / リソース層    | `chatLogResource.test.ts`, `chatApi.test.ts`, `roomCountsApi.test.ts` | キャッシュ / dedupe / paging / hasMore 等 |
-| ルーティング        | `routing.test.ts`（chat / chanari）                  | top / chat / chanari / unknown ルート解決                |
-| 統合                | `src/App.test.tsx`                                   | 各ルートが即時描画されること                             |
-| ビジュアル          | Storybook stories + Chromatic                        | UI のリグレッション                                      |
-| E2E (将来)          | （未実装）                                           | Playwright 等                                            |
+| 種別             | ファイル例                                                            | 主なカバー範囲                                                        |
+| ---------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| ユニット         | `*.test.ts`                                                           | 純関数 / ユーティリティ（例: `format.test.ts`, `countChars.test.ts`） |
+| コンポーネント   | `*.test.tsx`                                                          | React 部品の描画や UI 操作（例: `ChatLogList.test.tsx`）              |
+| カスタムフック   | `*.test.ts`                                                           | `useChatLog` / `useNowMinute` / `useParticipants` 等                  |
+| API / リソース層 | `chatLogResource.test.ts`, `chatApi.test.ts`, `roomCountsApi.test.ts` | キャッシュ / dedupe / paging / hasMore 等                             |
+| ルーティング     | `routing.test.ts`（chat / chanari）                                   | top / chat / chanari / unknown ルート解決                             |
+| 統合             | `src/App.test.tsx`                                                    | 各ルートが即時描画されること                                          |
+| ビジュアル       | Storybook stories + Chromatic                                         | UI のリグレッション                                                   |
+| E2E (将来)       | （未実装）                                                            | Playwright 等                                                         |
 
 - テストは **Testing Library** 中心、ユーザー目線重視
 - 外部 API（Supabase 等）・Web API（`localStorage`, `BroadcastChannel`, `requestIdleCallback`）は必要に応じてモック
@@ -93,17 +93,17 @@ src/features/chat/api/
 
 実装と doc がずれやすい挙動は、以下のテストで縛っています。修正時は対応するテストを必ず確認してください。
 
-| 不変条件                                                            | 主な保護テスト                                            |
-| ------------------------------------------------------------------- | --------------------------------------------------------- |
-| 同一 `roomId` への並行 `loadChatLogs` で Supabase は 1 回しか呼ばれない | `chatLogResource.test.ts`                                  |
-| `loadChatLogsWithPaging(roomId, 0, n)` は snapshot からスライスする | 同上                                                       |
-| キャッシュは `MAX_CHAT_LOG = 100` 件に trim される                  | 同上                                                       |
-| `useOptimistic` の reducer が temp と saved の重複を抑制する        | `useChatLog.test.ts`                                       |
-| `useParticipants` は同一 `chatLog` 参照では再計算しない             | `useParticipants.test.ts`                                  |
-| `ChatLogList` は同一 `chatLog` 参照では `slice` を再実行しない      | `ChatLogList.test.tsx`                                     |
-| `useNowMinute` は 1 分境界で更新される                              | `useNowMinute.test.ts`                                    |
-| `/chat/:roomId` / `/chanari/:roomId` / unknown が正しく解決される   | `routing.test.ts` / `chanari-chat/routing.test.ts`        |
-| 各ルートが即時描画される（ローディング fallback を挟まない）        | `App.test.tsx`                                             |
-| Supabase 未設定でもトップが破綻しない                               | `roomCountsApi.test.ts` / `TopPage.test.tsx`               |
+| 不変条件                                                                | 主な保護テスト                                     |
+| ----------------------------------------------------------------------- | -------------------------------------------------- |
+| 同一 `roomId` への並行 `loadChatLogs` で Supabase は 1 回しか呼ばれない | `chatLogResource.test.ts`                          |
+| `loadChatLogsWithPaging(roomId, 0, n)` は snapshot からスライスする     | 同上                                               |
+| キャッシュは `MAX_CHAT_LOG = 100` 件に trim される                      | 同上                                               |
+| `useOptimistic` の reducer が temp と saved の重複を抑制する            | `useChatLog.test.ts`                               |
+| `useParticipants` は同一 `chatLog` 参照では再計算しない                 | `useParticipants.test.ts`                          |
+| `ChatLogList` は同一 `chatLog` 参照では `slice` を再実行しない          | `ChatLogList.test.tsx`                             |
+| `useNowMinute` は 1 分境界で更新される                                  | `useNowMinute.test.ts`                             |
+| `/chat/:roomId` / `/chanari/:roomId` / unknown が正しく解決される       | `routing.test.ts` / `chanari-chat/routing.test.ts` |
+| 各ルートが即時描画される（ローディング fallback を挟まない）            | `App.test.tsx`                                     |
+| Supabase 未設定でもトップが破綻しない                                   | `roomCountsApi.test.ts` / `TopPage.test.tsx`       |
 
 ---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,12 @@ export default function App() {
     <>
       {route.type === 'top' && <TopRoute />}
       {route.type === 'chat-room' && <ChatRoute roomId={route.roomId} />}
-      {route.type === 'chanari-room' && <ChanariRoute roomId={route.roomId} />}
+      {/*
+        key={roomId}: ChanariChatPage は useState(settings.X) で入力 state を初期化するため
+        roomId 変化時に remount しないと別 room の入力 / 下書きが残ってしまう。
+        useChanariSettings 側にも useEffect の再 hydrate を入れているが、ここで remount を強制することが根本対策。
+      */}
+      {route.type === 'chanari-room' && <ChanariRoute key={route.roomId} roomId={route.roomId} />}
       {route.type === 'not-found' && <NotFoundRoute />}
     </>
   );

--- a/src/features/chanari-chat/ChanariChatPage.tsx
+++ b/src/features/chanari-chat/ChanariChatPage.tsx
@@ -59,8 +59,7 @@ export default function ChanariChatPage({ roomId }: { roomId: RoomId }) {
         top={
           <div className="chanari-scope">
             <ChanariTopHeader
-              backHref="https://chanari.com/"
-              helpHref="https://chanari.com/help/"
+              backHref={import.meta.env.BASE_URL}
               title={room.title}
               description={room.description}
               sloganLabel="ヽ(。д。)ﾉ常連さん募集中～！"

--- a/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
+++ b/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
@@ -1,10 +1,14 @@
 export type ChanariTopHeaderProps = {
   backHref: string;
-  helpHref: string;
+  helpHref?: string;
   title: string;
   description: string;
   sloganLabel?: string;
 };
+
+function isExternalHref(href: string): boolean {
+  return href.startsWith('http://') || href.startsWith('https://');
+}
 
 export default function ChanariTopHeader({
   backHref,
@@ -13,20 +17,31 @@ export default function ChanariTopHeader({
   description,
   sloganLabel,
 }: ChanariTopHeaderProps) {
+  const backExternal = isExternalHref(backHref);
+  const helpExternal = helpHref ? isExternalHref(helpHref) : false;
+
   return (
     <>
       <div id="chat-topheader">
         <div id="chat-topheader-left">
-          <a href={backHref} target="_blank" rel="noreferrer noopener">
+          <a
+            href={backHref}
+            {...(backExternal ? { target: '_blank', rel: 'noreferrer noopener' } : {})}
+          >
             なりきりチャットにもどる
           </a>
           {sloganLabel && <span>{sloganLabel}</span>}
         </div>
-        <div id="chat-topheader-right">
-          <a href={helpHref} target="_blank" rel="noreferrer noopener">
-            ヘルプ
-          </a>
-        </div>
+        {helpHref && (
+          <div id="chat-topheader-right">
+            <a
+              href={helpHref}
+              {...(helpExternal ? { target: '_blank', rel: 'noreferrer noopener' } : {})}
+            >
+              ヘルプ
+            </a>
+          </div>
+        )}
       </div>
       <div id="header">
         <p id="desc">{description}</p>

--- a/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
+++ b/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
@@ -8,8 +8,22 @@ export type ChanariTopHeaderProps = {
   sloganLabel?: string;
 };
 
+/**
+ * `href` が現在の origin の外を指しているかを判定する。
+ * 相対 URL や同一 origin の絶対 URL は false (= 内部リンク扱い、同タブ遷移) を返す。
+ *
+ * SSR や window 不在の環境では new URL() の base 解決ができないため、
+ * 接頭辞だけで判断するフォールバックを使う。
+ */
 function isExternalHref(href: string): boolean {
-  return href.startsWith('http://') || href.startsWith('https://');
+  if (typeof window === 'undefined' || !window.location) {
+    return href.startsWith('http://') || href.startsWith('https://');
+  }
+  try {
+    return new URL(href, window.location.href).origin !== window.location.origin;
+  } catch {
+    return false;
+  }
 }
 
 export default function ChanariTopHeader({

--- a/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
+++ b/src/features/chanari-chat/components/ChanariTopHeader/index.tsx
@@ -1,5 +1,7 @@
 export type ChanariTopHeaderProps = {
   backHref: string;
+  /** 戻るリンクの文言。省略時は遷移先が外部 URL かどうかで自動選択する。 */
+  backLabel?: string;
   helpHref?: string;
   title: string;
   description: string;
@@ -12,6 +14,7 @@ function isExternalHref(href: string): boolean {
 
 export default function ChanariTopHeader({
   backHref,
+  backLabel,
   helpHref,
   title,
   description,
@@ -19,6 +22,10 @@ export default function ChanariTopHeader({
 }: ChanariTopHeaderProps) {
   const backExternal = isExternalHref(backHref);
   const helpExternal = helpHref ? isExternalHref(helpHref) : false;
+  // backHref が in-app トップを指している既定状態では「お気楽チャットトップへ」と表示し、
+  // 外部のなりきりサイトに戻すユースケースでは従来の文言を使う。
+  const resolvedBackLabel =
+    backLabel ?? (backExternal ? 'なりきりチャットにもどる' : 'お気楽チャットトップへ');
 
   return (
     <>
@@ -28,7 +35,7 @@ export default function ChanariTopHeader({
             href={backHref}
             {...(backExternal ? { target: '_blank', rel: 'noreferrer noopener' } : {})}
           >
-            なりきりチャットにもどる
+            {resolvedBackLabel}
           </a>
           {sloganLabel && <span>{sloganLabel}</span>}
         </div>

--- a/src/features/chanari-chat/hooks/useChanariSettings.ts
+++ b/src/features/chanari-chat/hooks/useChanariSettings.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { loadDraft, saveDraft, type ChanariDraft } from '../utils/draftStore';
 
@@ -9,6 +9,16 @@ export function useChanariSettings(roomId: string) {
     const draft = loadDraft(roomId);
     return draft ?? {};
   });
+
+  // roomId が切り替わったときに別 room の draft を引きずらないよう再 hydrate する。
+  // 初回マウント時は useState の initializer で読み込み済みなのでスキップする。
+  const previousRoomIdRef = useRef(roomId);
+  useEffect(() => {
+    if (previousRoomIdRef.current === roomId) return;
+    previousRoomIdRef.current = roomId;
+    const draft = loadDraft(roomId);
+    setSettings(draft ?? {});
+  }, [roomId]);
 
   const updateSettings = useCallback(
     (partial: SettingsPartial) => {

--- a/src/features/chat/api/chatApi.test.ts
+++ b/src/features/chat/api/chatApi.test.ts
@@ -83,4 +83,42 @@ describe('chatApi', () => {
     expect(result.data).toHaveLength(80);
     expect(result.hasMore).toBe(false);
   });
+
+  describe('clearChatLogs', () => {
+    it('issues a logical delete (update deleted=true) scoped to the room', async () => {
+      // Supabase クエリビルダのチェイン: .update().eq().eq() を辿って await されることを再現する。
+      const eqDeleted = vi.fn(() => Promise.resolve({ error: null }));
+      const eqRoom = vi.fn(() => ({ eq: eqDeleted }));
+      const update = vi.fn(() => ({ eq: eqRoom }));
+
+      const { supabase } = await import('@shared/supabaseClient');
+      const from = supabase.from as Mock;
+      from.mockReset();
+      from.mockReturnValue({ update });
+
+      const chatApi = await import('./chatApi');
+      await chatApi.clearChatLogs(ROOM_ID);
+
+      // hard delete ではなく update({ deleted: true }) で呼ばれること
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update).toHaveBeenCalledWith({ deleted: true });
+      // room_id 一致 → deleted=false 一致 でフィルタされる (再削除や既消し行への二重 update を防ぐ)
+      expect(eqRoom).toHaveBeenCalledWith('room_id', ROOM_ID);
+      expect(eqDeleted).toHaveBeenCalledWith('deleted', false);
+    });
+
+    it('throws when supabase reports an error', async () => {
+      const eqDeleted = vi.fn(() => Promise.resolve({ error: { message: 'boom', code: '42' } }));
+      const eqRoom = vi.fn(() => ({ eq: eqDeleted }));
+      const update = vi.fn(() => ({ eq: eqRoom }));
+
+      const { supabase } = await import('@shared/supabaseClient');
+      const from = supabase.from as Mock;
+      from.mockReset();
+      from.mockReturnValue({ update });
+
+      const chatApi = await import('./chatApi');
+      await expect(chatApi.clearChatLogs(ROOM_ID)).rejects.toThrow(/boom/);
+    });
+  });
 });

--- a/src/features/chat/api/chatApi.test.ts
+++ b/src/features/chat/api/chatApi.test.ts
@@ -121,4 +121,234 @@ describe('chatApi', () => {
       await expect(chatApi.clearChatLogs(ROOM_ID)).rejects.toThrow(/boom/);
     });
   });
+
+  /**
+   * 再利用 helper: supabase.channel / removeChannel を差し替えて
+   * 1 つの "channel instance" を返す。次回 channel() 呼び出しまでは
+   * 同じインスタンスを共有することを呼び出し側で確認できる。
+   */
+  function installChannelMock() {
+    const postgresListeners: Array<(payload: { new: unknown }) => void> = [];
+    const broadcastListeners: Array<(payload: { payload: unknown }) => void> = [];
+    let pendingSend: { resolve: (value: string) => void } | null = null;
+
+    const channelInstance = {
+      on: vi.fn(
+        (
+          kind: string,
+          filter: Record<string, unknown> | { event?: string },
+          callback: (payload: unknown) => void
+        ) => {
+          if (kind === 'postgres_changes') {
+            postgresListeners.push(callback as (payload: { new: unknown }) => void);
+          } else if (kind === 'broadcast') {
+            broadcastListeners.push(callback as (payload: { payload: unknown }) => void);
+          }
+          // 未使用引数を ESLint 警告から守るためのダミー参照
+          void filter;
+          return channelInstance;
+        }
+      ),
+      subscribe: vi.fn(() => channelInstance),
+      send: vi.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            pendingSend = { resolve };
+          })
+      ),
+    };
+
+    const channel = vi.fn(() => channelInstance);
+    const removeChannel = vi.fn();
+
+    return {
+      channelInstance,
+      channel,
+      removeChannel,
+      postgresListeners,
+      broadcastListeners,
+      /** 直近の channel.send 呼び出しの Promise を resolve する */
+      resolvePendingSend() {
+        pendingSend?.resolve('ok');
+        pendingSend = null;
+      },
+    };
+  }
+
+  describe('subscribeChatLogs registry lifecycle', () => {
+    it('shares a single channel across concurrent subscribes for the same room', async () => {
+      const harness = installChannelMock();
+      const { supabase } = await import('@shared/supabaseClient');
+      (supabase as unknown as Record<string, unknown>).channel = harness.channel;
+      (supabase as unknown as Record<string, unknown>).removeChannel = harness.removeChannel;
+
+      const chatApi = await import('./chatApi');
+      const sub1 = chatApi.subscribeChatLogs(ROOM_ID, () => {});
+      const sub2 = chatApi.subscribeChatLogs(ROOM_ID, () => {});
+
+      // 同じ room 名で 2 回 subscribe しても supabase.channel は 1 回しか呼ばれない
+      expect(harness.channel).toHaveBeenCalledTimes(1);
+      expect(harness.channel).toHaveBeenCalledWith(`chats-postgres-${ROOM_ID}`);
+
+      // 1 回目の unsubscribe では channel を破棄しない
+      sub1.unsubscribe();
+      expect(harness.removeChannel).not.toHaveBeenCalled();
+
+      // 最後の unsubscribe で removeChannel が呼ばれて registry から消える
+      sub2.unsubscribe();
+      expect(harness.removeChannel).toHaveBeenCalledTimes(1);
+      expect(harness.removeChannel).toHaveBeenCalledWith(harness.channelInstance);
+    });
+
+    it('dispatches realtime INSERT payloads to all attached listeners', async () => {
+      const harness = installChannelMock();
+      const { supabase } = await import('@shared/supabaseClient');
+      (supabase as unknown as Record<string, unknown>).channel = harness.channel;
+      (supabase as unknown as Record<string, unknown>).removeChannel = harness.removeChannel;
+
+      const chatApi = await import('./chatApi');
+      const calls1: Chat[] = [];
+      const calls2: Chat[] = [];
+      const sub1 = chatApi.subscribeChatLogs(ROOM_ID, (chat) => calls1.push(chat));
+      const sub2 = chatApi.subscribeChatLogs(ROOM_ID, (chat) => calls2.push(chat));
+
+      const inserted = makeChat(1);
+      // registry の on() は 1 度だけ呼ばれ、その中で内部 dispatch される設計
+      harness.postgresListeners[0]({ new: inserted });
+
+      expect(calls1).toHaveLength(1);
+      expect(calls2).toHaveLength(1);
+      expect(calls1[0].uuid).toBe(inserted.uuid);
+      expect(calls2[0].uuid).toBe(inserted.uuid);
+
+      sub1.unsubscribe();
+      sub2.unsubscribe();
+    });
+  });
+
+  describe('broadcast send-only channel cleanup', () => {
+    it('removes the channel after a send when no listener is attached', async () => {
+      const harness = installChannelMock();
+      const { supabase } = await import('@shared/supabaseClient');
+      (supabase as unknown as Record<string, unknown>).channel = harness.channel;
+      (supabase as unknown as Record<string, unknown>).removeChannel = harness.removeChannel;
+
+      const chatApi = await import('./chatApi');
+      chatApi.broadcastLookEvent(ROOM_ID, 'msg-1');
+
+      expect(harness.channel).toHaveBeenCalledWith(`chats-broadcast-${ROOM_ID}`);
+      expect(harness.removeChannel).not.toHaveBeenCalled();
+
+      // send が解決した後に cleanup が走る
+      harness.resolvePendingSend();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.removeChannel).toHaveBeenCalledTimes(1);
+      expect(harness.removeChannel).toHaveBeenCalledWith(harness.channelInstance);
+    });
+
+    it('keeps the channel when an active listener is attached', async () => {
+      const harness = installChannelMock();
+      const { supabase } = await import('@shared/supabaseClient');
+      (supabase as unknown as Record<string, unknown>).channel = harness.channel;
+      (supabase as unknown as Record<string, unknown>).removeChannel = harness.removeChannel;
+
+      const chatApi = await import('./chatApi');
+      const unsub = chatApi.onLookBroadcast(ROOM_ID, () => {});
+
+      chatApi.broadcastLookEvent(ROOM_ID, 'msg-1');
+      harness.resolvePendingSend();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // listener が居る間は send 完了後も channel を維持する
+      expect(harness.removeChannel).not.toHaveBeenCalled();
+
+      // listener 解除で初めて removeChannel が走る
+      unsub();
+      expect(harness.removeChannel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not remove the channel when a listener is added between send call and send completion', async () => {
+      const harness = installChannelMock();
+      const { supabase } = await import('@shared/supabaseClient');
+      (supabase as unknown as Record<string, unknown>).channel = harness.channel;
+      (supabase as unknown as Record<string, unknown>).removeChannel = harness.removeChannel;
+
+      const chatApi = await import('./chatApi');
+      // listener=0 で send 開始 → finally 内で hadListeners=false が記録される
+      chatApi.broadcastLookEvent(ROOM_ID, 'msg-1');
+      // 送信完了前に listener が登録されると、cleanup は size>0 を見て maintain する
+      const unsub = chatApi.onLookBroadcast(ROOM_ID, () => {});
+
+      harness.resolvePendingSend();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.removeChannel).not.toHaveBeenCalled();
+      unsub();
+      expect(harness.removeChannel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createOptimisticChat', () => {
+    it('attaches a fresh optimisticNonce while preserving caller-supplied metadata', async () => {
+      const chatApi = await import('./chatApi');
+      const result = chatApi.createOptimisticChat({
+        room_id: ROOM_ID,
+        name: 'Taro',
+        color: '#f00',
+        message: 'Hello',
+        client_time: 0, // overwritten by helper
+        ip: '',
+        ua: '',
+        metadata: { version: 1, fontStyle: { bold: true } },
+      });
+
+      expect(result.uuid.startsWith('temp-')).toBe(true);
+      expect(result.optimistic).toBe(true);
+      expect(typeof result.client_time).toBe('number');
+      // time は先頭表示保証用に +1 年シフトされている
+      expect(result.time).toBeGreaterThan((result.client_time ?? 0) + 300 * 24 * 60 * 60 * 1000);
+      expect(result.metadata?.fontStyle).toEqual({ bold: true });
+      expect(typeof result.metadata?.optimisticNonce).toBe('string');
+      expect((result.metadata?.optimisticNonce ?? '').length).toBeGreaterThan(0);
+    });
+
+    it('generates a unique nonce per call', async () => {
+      const chatApi = await import('./chatApi');
+      const base = {
+        room_id: ROOM_ID,
+        name: 'Taro',
+        color: '#f00',
+        message: 'Hello',
+        client_time: 0,
+        ip: '',
+        ua: '',
+      };
+      const a = chatApi.createOptimisticChat(base);
+      const b = chatApi.createOptimisticChat(base);
+
+      expect(a.metadata?.optimisticNonce).toBeDefined();
+      expect(b.metadata?.optimisticNonce).toBeDefined();
+      expect(a.metadata?.optimisticNonce).not.toBe(b.metadata?.optimisticNonce);
+    });
+
+    it('synthesizes a default metadata object when none is provided', async () => {
+      const chatApi = await import('./chatApi');
+      const result = chatApi.createOptimisticChat({
+        room_id: ROOM_ID,
+        name: 'Taro',
+        color: '#f00',
+        message: 'Hello',
+        client_time: 0,
+        ip: '',
+        ua: '',
+      });
+
+      expect(result.metadata?.version).toBe(1);
+      expect(typeof result.metadata?.optimisticNonce).toBe('string');
+    });
+  });
 });

--- a/src/features/chat/api/chatApi.test.ts
+++ b/src/features/chat/api/chatApi.test.ts
@@ -51,18 +51,36 @@ describe('chatApi', () => {
     expect(typeof chatApi.subscribeChatLogs).toBe('function');
   });
 
-  it('keeps offset-zero paging hasMore conservative when snapshot reaches the requested limit', async () => {
+  it('reports hasMore=true when the snapshot is capped (table has more than MAX_CHAT_LOG rows)', async () => {
+    // chatLogResource は MAX_CHAT_LOG + 1 件を要求し、超過の有無で hasMore を判定する。
+    // ここでは 101 件の mock を返し、「table にさらに続きがある」状況を再現する。
     const { supabase } = await import('@shared/supabaseClient');
     const from = supabase.from as Mock;
     from.mockReset();
     from.mockReturnValue(
-      createQueryMock(Array.from({ length: 100 }, (_, index) => makeChat(index)))
+      createQueryMock(Array.from({ length: 101 }, (_, index) => makeChat(index)))
     );
 
     const chatApi = await import('./chatApi');
     const result = await chatApi.loadChatLogsWithPaging(ROOM_ID, 100, 0, true);
 
+    // 超過分は表示・キャッシュに含めずに 100 件へ trim する
     expect(result.data).toHaveLength(100);
     expect(result.hasMore).toBe(true);
+  });
+
+  it('reports hasMore=false when the snapshot does not reach MAX_CHAT_LOG', async () => {
+    const { supabase } = await import('@shared/supabaseClient');
+    const from = supabase.from as Mock;
+    from.mockReset();
+    from.mockReturnValue(
+      createQueryMock(Array.from({ length: 80 }, (_, index) => makeChat(index)))
+    );
+
+    const chatApi = await import('./chatApi');
+    const result = await chatApi.loadChatLogsWithPaging(ROOM_ID, 100, 0, true);
+
+    expect(result.data).toHaveLength(80);
+    expect(result.hasMore).toBe(false);
   });
 });

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -276,6 +276,11 @@ export async function invalidateCacheAsync(): Promise<void> {
 }
 
 // 楽観的更新用のヘルパー関数
+// 楽観的更新中の time は「サーバー時刻より十分先」に置き、ChatLogList の
+// time-desc フォールバック sort で常に先頭に来ることを保証する。
+// savedChat にマージされた時点でサーバー側の正しい time に置換される。
+const OPTIMISTIC_TIME_OFFSET_MS = 365 * 24 * 60 * 60 * 1000;
+
 export function createOptimisticChat(chatData: Omit<Chat, 'uuid' | 'time' | 'optimistic'>): Chat {
   // optimisticNonce: 楽観的更新の重複表示防止用のランダム識別子。
   // saveChatLogOptimistic がそのまま metadata に詰めて保存し、
@@ -285,12 +290,13 @@ export function createOptimisticChat(chatData: Omit<Chat, 'uuid' | 'time' | 'opt
     typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  const now = Date.now();
   const baseMetadata = chatData.metadata ?? { version: 1 as const };
   return {
     ...chatData,
-    uuid: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`, // 一時UUID
-    time: Date.now(), // クライアント側の一時的なタイムスタンプ
-    client_time: Date.now(),
+    uuid: `temp-${now}-${Math.random().toString(36).substr(2, 9)}`, // 一時UUID
+    time: now + OPTIMISTIC_TIME_OFFSET_MS, // 先頭表示保証用の未来時刻
+    client_time: now,
     optimistic: true,
     metadata: { ...baseMetadata, optimisticNonce: nonce },
   };

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -7,6 +7,7 @@ import { normalizeChat } from '../utils/normalizeMetadata';
 import { DEFAULT_ROOM_ID, type RoomId } from '../rooms';
 import {
   loadChatLogs as resourceLoadChatLogs,
+  loadChatLogsSnapshot as resourceLoadChatLogsSnapshot,
   loadChatLogsWithPaging as resourceLoadChatLogsWithPaging,
   loadInitialChatLogs as resourceLoadInitialChatLogs,
   invalidateCache as resourceInvalidateCache,
@@ -14,9 +15,8 @@ import {
   replaceOptimisticInCache,
   getCacheInfo as resourceGetCacheInfo,
   getPagingHasMore,
-  getSnapshotHasMore,
 } from './chatLogResource';
-export { prefetchChatLogs } from './chatLogResource';
+export { prefetchChatLogs, getSnapshotHasMore } from './chatLogResource';
 
 const TABLE = 'chats';
 
@@ -83,15 +83,21 @@ export async function loadChatLogsWithPaging(
   useCache = true
 ): Promise<{ data: Chat[]; hasMore: boolean }> {
   if (offset === 0) {
-    const snapshot = await resourceLoadChatLogs(roomId, useCache);
+    // hasMore は snapshot 取得と同じ往復で確定した値を使う。
+    // resourceLoadChatLogsSnapshot は { data, hasMore } を返すため、
+    // 取得中に invalidateCache が走って世代が変わっても、この呼び出し固有の
+    // hasMore がロストすることはない (#15 対策)。
+    const { data: snapshot, hasMore: snapshotHasMore } = await resourceLoadChatLogsSnapshot(
+      roomId,
+      useCache
+    );
     // hasMore は次の 2 条件のいずれかで真:
     //   (1) 要求 limit より snapshot が長い → snapshot 内に未表示分がある
     //   (2) snapshot 自体が canonical cap (MAX_CHAT_LOG) に張り付いており、
     //       テーブルにさらに続きが存在することが分かっている
-    const snapshotHasMoreFlag = getSnapshotHasMore(roomId) ?? false;
     return {
       data: snapshot.slice(0, limit),
-      hasMore: snapshot.length > limit || snapshotHasMoreFlag,
+      hasMore: snapshot.length > limit || snapshotHasMore === true,
     };
   }
 

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -14,6 +14,7 @@ import {
   replaceOptimisticInCache,
   getCacheInfo as resourceGetCacheInfo,
   getPagingHasMore,
+  getSnapshotHasMore,
 } from './chatLogResource';
 export { prefetchChatLogs } from './chatLogResource';
 
@@ -83,9 +84,14 @@ export async function loadChatLogsWithPaging(
 ): Promise<{ data: Chat[]; hasMore: boolean }> {
   if (offset === 0) {
     const snapshot = await resourceLoadChatLogs(roomId, useCache);
+    // hasMore は次の 2 条件のいずれかで真:
+    //   (1) 要求 limit より snapshot が長い → snapshot 内に未表示分がある
+    //   (2) snapshot 自体が canonical cap (MAX_CHAT_LOG) に張り付いており、
+    //       テーブルにさらに続きが存在することが分かっている
+    const snapshotHasMoreFlag = getSnapshotHasMore(roomId) ?? false;
     return {
       data: snapshot.slice(0, limit),
-      hasMore: snapshot.length >= limit,
+      hasMore: snapshot.length > limit || snapshotHasMoreFlag,
     };
   }
 
@@ -226,9 +232,16 @@ export function saveChatLogFireAndForget(chat: Chat): Promise<void> {
 }
 
 export async function clearChatLogs(roomId: RoomId = DEFAULT_ROOM_ID): Promise<void> {
-  await supabase.from(TABLE).delete().eq('room_id', roomId).neq('uuid', '');
-
-  // チャットログがクリアされたらキャッシュを無効化
+  // 論理削除に統一: SELECT 側は .eq('deleted', false) でフィルタしているため、
+  // hard delete ではなく deleted フラグを立てることで clearChatLogsByName と整合する。
+  const { error } = await supabase
+    .from(TABLE)
+    .update({ deleted: true })
+    .eq('room_id', roomId)
+    .eq('deleted', false);
+  if (error) {
+    throw new Error(`Failed to clear chat logs: ${error.message}`);
+  }
   invalidateCache(roomId);
 }
 
@@ -264,12 +277,22 @@ export async function invalidateCacheAsync(): Promise<void> {
 
 // 楽観的更新用のヘルパー関数
 export function createOptimisticChat(chatData: Omit<Chat, 'uuid' | 'time' | 'optimistic'>): Chat {
+  // optimisticNonce: 楽観的更新の重複表示防止用のランダム識別子。
+  // saveChatLogOptimistic がそのまま metadata に詰めて保存し、
+  // realtime INSERT で同じ nonce が echo されるため、temp UUID と savedChat の
+  // 同一性判定 (reduceOptimisticChat) を (client_time + name + message) より厳密に行える。
+  const nonce =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  const baseMetadata = chatData.metadata ?? { version: 1 as const };
   return {
     ...chatData,
     uuid: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`, // 一時UUID
     time: Date.now(), // クライアント側の一時的なタイムスタンプ
     client_time: Date.now(),
     optimistic: true,
+    metadata: { ...baseMetadata, optimisticNonce: nonce },
   };
 }
 
@@ -333,68 +356,103 @@ export async function loadChatLogsByTimeRange(
 }
 
 // --- Realtime チャネル管理 ---
+//
+// room 単位で 1 channel を共有し、refCount で生死を管理する設計。
+// 同 room に対する複数 subscribe (StrictMode の二重 mount 含む) を
+// 同一 channel 上の listener Set に集約することで、
+// `chats-postgres-${roomId}` 等の channel 名衝突と leak を回避する。
 
-// Broadcast 用の共有チャネル
-const broadcastChannels: Partial<Record<RoomId, RealtimeChannel>> = {};
-const broadcastSubscribed = new Set<RoomId>();
+export type LookEvent = { type: 'look'; messageId: string } | { type: 'unlook' };
 
-// look イベントのコールバック集合（StrictMode の二重登録に強い設計）
-const lookCallbacks = new Map<RoomId, Set<(event: LookEvent) => void>>();
-const lookListenersAttached = new Set<RoomId>();
+type PostgresListener = (chat: Chat) => void;
+type LookListener = (event: LookEvent) => void;
 
-function getOrCreateLookCallbacks(roomId: RoomId): Set<(event: LookEvent) => void> {
-  if (!lookCallbacks.has(roomId)) {
-    lookCallbacks.set(roomId, new Set());
-  }
-  return lookCallbacks.get(roomId)!;
-}
+// Postgres Changes (INSERT) の購読 registry
+type PostgresEntry = {
+  channel: RealtimeChannel;
+  listeners: Set<PostgresListener>;
+};
+const postgresEntries = new Map<RoomId, PostgresEntry>();
 
-function getOrCreateBroadcastChannel(roomId: RoomId): RealtimeChannel {
-  if (!broadcastChannels[roomId]) {
-    broadcastChannels[roomId] = supabase.channel(`chats-broadcast-${roomId}`);
-  }
-  return broadcastChannels[roomId]!;
-}
+// Broadcast (look/unlook) の購読 registry
+type BroadcastEntry = {
+  channel: RealtimeChannel;
+  listeners: Set<LookListener>;
+};
+const broadcastEntries = new Map<RoomId, BroadcastEntry>();
 
-function ensureBroadcastSubscribed(roomId: RoomId): void {
-  if (!broadcastSubscribed.has(roomId)) {
-    getOrCreateBroadcastChannel(roomId).subscribe();
-    broadcastSubscribed.add(roomId);
-  }
-}
-
-function ensureLookListenerAttached(roomId: RoomId): void {
-  if (lookListenersAttached.has(roomId)) return;
-  const channel = getOrCreateBroadcastChannel(roomId);
-  channel.on('broadcast', { event: 'look' }, (payload) => {
-    const event = payload.payload as LookEvent;
-    // 登録されているすべてのコールバックに dispatch
-    for (const cb of getOrCreateLookCallbacks(roomId)) cb(event);
-  });
-  lookListenersAttached.add(roomId);
-}
-
-// Postgres Changes 用（subscribeChatLogs 専用チャネル）
-export function subscribeChatLogs(roomId: RoomId, callback: (chat: Chat) => void) {
+function createPostgresEntry(roomId: RoomId): PostgresEntry {
+  const listeners = new Set<PostgresListener>();
   const channel = supabase
     .channel(`chats-postgres-${roomId}`)
     .on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: TABLE, filter: `room_id=eq.${roomId}` },
-      (payload) => callback(normalizeChat(payload.new))
+      (payload) => {
+        const chat = normalizeChat(payload.new);
+        for (const listener of listeners) listener(chat);
+      }
     )
     .subscribe();
-  return channel;
+  return { channel, listeners };
+}
+
+function createBroadcastEntry(roomId: RoomId): BroadcastEntry {
+  const listeners = new Set<LookListener>();
+  const channel = supabase
+    .channel(`chats-broadcast-${roomId}`)
+    .on('broadcast', { event: 'look' }, (payload) => {
+      const event = payload.payload as LookEvent;
+      for (const listener of listeners) listener(event);
+    })
+    .subscribe();
+  return { channel, listeners };
+}
+
+function getOrCreateBroadcastEntry(roomId: RoomId): BroadcastEntry {
+  let entry = broadcastEntries.get(roomId);
+  if (!entry) {
+    entry = createBroadcastEntry(roomId);
+    broadcastEntries.set(roomId, entry);
+  }
+  return entry;
+}
+
+/**
+ * Postgres Changes 用の購読を登録する。
+ * 同 room の複数購読者は同一 channel を共有し、最後の解除で channel が破棄される。
+ */
+export function subscribeChatLogs(
+  roomId: RoomId,
+  callback: PostgresListener
+): { unsubscribe: () => void } {
+  let entry = postgresEntries.get(roomId);
+  if (!entry) {
+    entry = createPostgresEntry(roomId);
+    postgresEntries.set(roomId, entry);
+  }
+  entry.listeners.add(callback);
+
+  return {
+    unsubscribe() {
+      const current = postgresEntries.get(roomId);
+      if (!current) return;
+      current.listeners.delete(callback);
+      if (current.listeners.size === 0) {
+        supabase.removeChannel(current.channel);
+        postgresEntries.delete(roomId);
+      }
+    },
+  };
 }
 
 // --- Broadcast: look/unlook イベント ---
 
-export type LookEvent = { type: 'look'; messageId: string } | { type: 'unlook' };
-
 export function broadcastLookEvent(roomId: RoomId, messageId: string): void {
-  const channel = getOrCreateBroadcastChannel(roomId);
-  ensureBroadcastSubscribed(roomId);
-  channel.send({
+  // 送信は listener が居ない部屋でも channel を起こす必要があるが、
+  // listener 0 のままだと cleanup タイミングが無いので listener 解除時に揃えて落とす。
+  const entry = getOrCreateBroadcastEntry(roomId);
+  entry.channel.send({
     type: 'broadcast',
     event: 'look',
     payload: { type: 'look', messageId } satisfies LookEvent,
@@ -402,22 +460,24 @@ export function broadcastLookEvent(roomId: RoomId, messageId: string): void {
 }
 
 export function broadcastUnlookEvent(roomId: RoomId): void {
-  const channel = getOrCreateBroadcastChannel(roomId);
-  ensureBroadcastSubscribed(roomId);
-  channel.send({
+  const entry = getOrCreateBroadcastEntry(roomId);
+  entry.channel.send({
     type: 'broadcast',
     event: 'look',
     payload: { type: 'unlook' } satisfies LookEvent,
   });
 }
 
-export function onLookBroadcast(roomId: RoomId, callback: (event: LookEvent) => void): () => void {
-  ensureLookListenerAttached(roomId);
-  ensureBroadcastSubscribed(roomId);
-  const roomCallbacks = getOrCreateLookCallbacks(roomId);
-  roomCallbacks.add(callback);
-  // コールバック集合からの削除で解除できる（StrictMode の二重登録にも耐える）
+export function onLookBroadcast(roomId: RoomId, callback: LookListener): () => void {
+  const entry = getOrCreateBroadcastEntry(roomId);
+  entry.listeners.add(callback);
   return () => {
-    roomCallbacks.delete(callback);
+    const current = broadcastEntries.get(roomId);
+    if (!current) return;
+    current.listeners.delete(callback);
+    if (current.listeners.size === 0) {
+      supabase.removeChannel(current.channel);
+      broadcastEntries.delete(roomId);
+    }
   };
 }

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -454,24 +454,31 @@ export function subscribeChatLogs(
 
 // --- Broadcast: look/unlook イベント ---
 
-export function broadcastLookEvent(roomId: RoomId, messageId: string): void {
-  // 送信は listener が居ない部屋でも channel を起こす必要があるが、
-  // listener 0 のままだと cleanup タイミングが無いので listener 解除時に揃えて落とす。
+// send-only 利用 (listener 0) で起こした channel は send 後に明示破棄する。
+// onLookBroadcast 経路で listener が既に存在する場合は通常の refCount cleanup に任せる。
+function sendBroadcastLookPayload(roomId: RoomId, payload: LookEvent): void {
+  const hadListeners = (broadcastEntries.get(roomId)?.listeners.size ?? 0) > 0;
   const entry = getOrCreateBroadcastEntry(roomId);
-  entry.channel.send({
-    type: 'broadcast',
-    event: 'look',
-    payload: { type: 'look', messageId } satisfies LookEvent,
+  // channel.send は Promise を返す。listener が居なかった場合は送信完了後に
+  // (= 他に listener が追加されていないことを確認したうえで) channel を破棄する。
+  void Promise.resolve(
+    entry.channel.send({ type: 'broadcast', event: 'look', payload })
+  ).finally(() => {
+    if (hadListeners) return;
+    const current = broadcastEntries.get(roomId);
+    if (!current) return;
+    if (current.listeners.size > 0) return; // 送信中に listener が登録されていたら維持
+    supabase.removeChannel(current.channel);
+    broadcastEntries.delete(roomId);
   });
 }
 
+export function broadcastLookEvent(roomId: RoomId, messageId: string): void {
+  sendBroadcastLookPayload(roomId, { type: 'look', messageId });
+}
+
 export function broadcastUnlookEvent(roomId: RoomId): void {
-  const entry = getOrCreateBroadcastEntry(roomId);
-  entry.channel.send({
-    type: 'broadcast',
-    event: 'look',
-    payload: { type: 'unlook' } satisfies LookEvent,
-  });
+  sendBroadcastLookPayload(roomId, { type: 'unlook' });
 }
 
 export function onLookBroadcast(roomId: RoomId, callback: LookListener): () => void {

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -461,16 +461,16 @@ function sendBroadcastLookPayload(roomId: RoomId, payload: LookEvent): void {
   const entry = getOrCreateBroadcastEntry(roomId);
   // channel.send は Promise を返す。listener が居なかった場合は送信完了後に
   // (= 他に listener が追加されていないことを確認したうえで) channel を破棄する。
-  void Promise.resolve(
-    entry.channel.send({ type: 'broadcast', event: 'look', payload })
-  ).finally(() => {
-    if (hadListeners) return;
-    const current = broadcastEntries.get(roomId);
-    if (!current) return;
-    if (current.listeners.size > 0) return; // 送信中に listener が登録されていたら維持
-    supabase.removeChannel(current.channel);
-    broadcastEntries.delete(roomId);
-  });
+  void Promise.resolve(entry.channel.send({ type: 'broadcast', event: 'look', payload })).finally(
+    () => {
+      if (hadListeners) return;
+      const current = broadcastEntries.get(roomId);
+      if (!current) return;
+      if (current.listeners.size > 0) return; // 送信中に listener が登録されていたら維持
+      supabase.removeChannel(current.channel);
+      broadcastEntries.delete(roomId);
+    }
+  );
 }
 
 export function broadcastLookEvent(roomId: RoomId, messageId: string): void {

--- a/src/features/chat/api/chatLogResource.ts
+++ b/src/features/chat/api/chatLogResource.ts
@@ -11,18 +11,28 @@ const CACHE_DURATION = 5 * 60 * 1000;
 
 interface CacheEntry {
   data: Chat[];
+  /**
+   * canonical snapshot がテーブルの全件を含んでいない (= さらに続きが存在する) かどうか。
+   * フェッチ時に `MAX_CHAT_LOG + 1` 件取得して判定し、ここに同梱する。
+   * オフラインフォールバック中などで判定できなかった場合は undefined。
+   */
+  hasMore: boolean | undefined;
   timestamp: number;
 }
 
+/** canonical snapshot 1 回分の戻り値 shape。 */
+export type SnapshotResult = { data: Chat[]; hasMore: boolean | undefined };
+
 const cache = new Map<RoomId, CacheEntry>();
-const snapshotInflight = new Map<RoomId, Promise<Chat[]>>();
+const snapshotInflight = new Map<RoomId, Promise<SnapshotResult>>();
 const pagingInflight = new Map<string, Promise<Chat[]>>();
 const pagingHasMore = new Map<string, boolean>();
 const cacheGeneration = new Map<RoomId, number>();
 /**
  * canonical snapshot がテーブルの全件を含んでいない (= さらに続きが存在する) かどうか。
- * `MAX_CHAT_LOG + 1` 件をフェッチして `MAX_CHAT_LOG` 件を超えていたら true。
- * room が未取得 / オフラインフォールバック中は undefined。
+ * `loadChatLogsSnapshot` の戻り値と同期して更新される観測用 Map。
+ * 競合に強い呼び出しは戻り値の `hasMore` を優先し、こちらは外部の単発参照に使う。
+ * 未取得 / オフラインフォールバック中は undefined を返すよう delete される。
  */
 const snapshotHasMore = new Map<RoomId, boolean>();
 
@@ -69,9 +79,14 @@ function isFreshCache(entry: CacheEntry): boolean {
   return Date.now() - entry.timestamp < CACHE_DURATION;
 }
 
-function setCachedChatLogs(roomId: RoomId, data: Chat[]): void {
+function setCachedChatLogs(
+  roomId: RoomId,
+  data: Chat[],
+  hasMore: boolean | undefined
+): void {
   cache.set(roomId, {
     data: data.slice(0, MAX_CHAT_LOG),
+    hasMore,
     timestamp: Date.now(),
   });
 }
@@ -92,16 +107,16 @@ async function fetchSnapshot(
   roomId: RoomId,
   generation: number,
   startTime: number
-): Promise<Chat[]> {
+): Promise<SnapshotResult> {
   return retryApiCall(async () => {
     if (!isOnline()) {
       endPerf('loadChatLogs-offline', startTime);
-      // オフラインフォールバック中は「続きがあるか」を確定できないため、エントリ自体を削除して
-      // getSnapshotHasMore は undefined を返す ("未取得" 状態) ようにする。
+      // オフラインフォールバック中は「続きがあるか」を確定できない。
+      // 戻り値で undefined を返しつつ、観測 Map も最新 generation なら "未取得" 状態にする。
       if (getCacheGeneration(roomId) === generation) {
         snapshotHasMore.delete(roomId);
       }
-      return getOfflineChatData(roomId);
+      return { data: getOfflineChatData(roomId), hasMore: undefined };
     }
 
     // hasMore を正確に返すため MAX_CHAT_LOG + 1 件取得し、超過分の有無で判定する。
@@ -120,7 +135,7 @@ async function fetchSnapshot(
         if (getCacheGeneration(roomId) === generation) {
           snapshotHasMore.delete(roomId);
         }
-        return getOfflineChatData(roomId);
+        return { data: getOfflineChatData(roomId), hasMore: undefined };
       }
 
       throw new Error(`Supabase error: ${error.message} (${error.code})`);
@@ -129,13 +144,15 @@ async function fetchSnapshot(
     const rows = (data ?? []).map(normalizeChat);
     const hasMore = rows.length > MAX_CHAT_LOG;
     const chatData = hasMore ? rows.slice(0, MAX_CHAT_LOG) : rows;
+    // generation が古いと判明した場合でも戻り値の hasMore は呼び出し元に渡す
+    // (caller が取得結果と一緒に判定できるよう、stale 応答であっても情報を失わない)。
     if (getCacheGeneration(roomId) === generation) {
-      setCachedChatLogs(roomId, chatData);
+      setCachedChatLogs(roomId, chatData, hasMore);
       snapshotHasMore.set(roomId, hasMore);
     }
     endPerf('loadChatLogs-network', startTime);
 
-    return chatData;
+    return { data: chatData, hasMore };
   });
 }
 
@@ -181,16 +198,22 @@ async function fetchPage(
   });
 }
 
-export async function loadChatLogs(
+/**
+ * canonical snapshot を `{ data, hasMore }` shape で返す。
+ * 取得タイミングで決まった hasMore を取得結果と必ずペアで返すため、
+ * 取得中に `invalidateCache` が走って generation が変わっても
+ * 呼び出し元はそのリクエスト固有の hasMore を信頼できる。
+ */
+export async function loadChatLogsSnapshot(
   roomId: RoomId = DEFAULT_ROOM_ID,
   useCache = true
-): Promise<Chat[]> {
+): Promise<SnapshotResult> {
   const startTime = startPerf();
 
   const cached = getCachedChatLogs(roomId);
   if (useCache && cached && isFreshCache(cached)) {
     endPerf('loadChatLogs-cache', startTime);
-    return cached.data;
+    return { data: cached.data, hasMore: cached.hasMore };
   }
 
   const inflight = snapshotInflight.get(roomId);
@@ -199,7 +222,7 @@ export async function loadChatLogs(
   }
 
   const generation = getCacheGeneration(roomId);
-  let request: Promise<Chat[]>;
+  let request: Promise<SnapshotResult>;
   request = fetchSnapshot(roomId, generation, startTime).finally(() => {
     if (snapshotInflight.get(roomId) === request) {
       snapshotInflight.delete(roomId);
@@ -207,6 +230,18 @@ export async function loadChatLogs(
   });
   snapshotInflight.set(roomId, request);
   return request;
+}
+
+/**
+ * canonical snapshot を Chat[] のみで返す後方互換 API。
+ * hasMore も必要な呼び出し元は `loadChatLogsSnapshot` を直接使うこと。
+ */
+export async function loadChatLogs(
+  roomId: RoomId = DEFAULT_ROOM_ID,
+  useCache = true
+): Promise<Chat[]> {
+  const { data } = await loadChatLogsSnapshot(roomId, useCache);
+  return data;
 }
 
 export async function loadChatLogsWithPaging(
@@ -221,8 +256,8 @@ export async function loadChatLogsWithPaging(
         `loadChatLogsWithPaging requested ${limit} rows; canonical snapshot is capped at ${MAX_CHAT_LOG}`
       );
     }
-    const snapshot = await loadChatLogs(roomId, useCache);
-    return snapshot.slice(0, limit);
+    const { data } = await loadChatLogsSnapshot(roomId, useCache);
+    return data.slice(0, limit);
   }
 
   const key = getPagingKey(roomId, offset, limit);
@@ -252,7 +287,7 @@ export async function loadInitialChatLogs(
 
 export async function prefetchChatLogs(roomId: RoomId = DEFAULT_ROOM_ID): Promise<void> {
   try {
-    await loadChatLogs(roomId);
+    await loadChatLogsSnapshot(roomId);
   } catch {
     // Best-effort prefetch only.
   }
@@ -304,7 +339,7 @@ export function applyOptimisticToCache(roomId: RoomId, chat: Chat): void {
   const roomCache = getCachedChatLogs(roomId);
   if (!roomCache) return;
 
-  setCachedChatLogs(roomId, [chat, ...roomCache.data]);
+  setCachedChatLogs(roomId, [chat, ...roomCache.data], roomCache.hasMore);
 }
 
 export function replaceOptimisticInCache(optimisticUuid: string, serverChat: Chat): void {
@@ -317,7 +352,7 @@ export function replaceOptimisticInCache(optimisticUuid: string, serverChat: Cha
 
   const next = [...roomCache.data];
   next[index] = serverChat;
-  setCachedChatLogs(roomId, next);
+  setCachedChatLogs(roomId, next, roomCache.hasMore);
 }
 
 export function getCacheInfo(roomId: RoomId = DEFAULT_ROOM_ID): { cached: boolean; age?: number } {
@@ -350,6 +385,7 @@ export function getSnapshotHasMore(roomId: RoomId): boolean | undefined {
 
 export const chatLogResource = {
   loadChatLogs,
+  loadChatLogsSnapshot,
   loadChatLogsWithPaging,
   loadInitialChatLogs,
   prefetchChatLogs,

--- a/src/features/chat/api/chatLogResource.ts
+++ b/src/features/chat/api/chatLogResource.ts
@@ -79,11 +79,7 @@ function isFreshCache(entry: CacheEntry): boolean {
   return Date.now() - entry.timestamp < CACHE_DURATION;
 }
 
-function setCachedChatLogs(
-  roomId: RoomId,
-  data: Chat[],
-  hasMore: boolean | undefined
-): void {
+function setCachedChatLogs(roomId: RoomId, data: Chat[], hasMore: boolean | undefined): void {
   cache.set(roomId, {
     data: data.slice(0, MAX_CHAT_LOG),
     hasMore,

--- a/src/features/chat/api/chatLogResource.ts
+++ b/src/features/chat/api/chatLogResource.ts
@@ -19,6 +19,12 @@ const snapshotInflight = new Map<RoomId, Promise<Chat[]>>();
 const pagingInflight = new Map<string, Promise<Chat[]>>();
 const pagingHasMore = new Map<string, boolean>();
 const cacheGeneration = new Map<RoomId, number>();
+/**
+ * canonical snapshot がテーブルの全件を含んでいない (= さらに続きが存在する) かどうか。
+ * `MAX_CHAT_LOG + 1` 件をフェッチして `MAX_CHAT_LOG` 件を超えていたら true。
+ * room が未取得 / オフラインフォールバック中は undefined。
+ */
+const snapshotHasMore = new Map<RoomId, boolean>();
 
 function startPerf(): number {
   return performance.now();
@@ -90,28 +96,40 @@ async function fetchSnapshot(
   return retryApiCall(async () => {
     if (!isOnline()) {
       endPerf('loadChatLogs-offline', startTime);
+      // オフラインフォールバック中は「続きがあるか」は不明なので false 扱い。
+      if (getCacheGeneration(roomId) === generation) {
+        snapshotHasMore.set(roomId, false);
+      }
       return getOfflineChatData(roomId);
     }
 
+    // hasMore を正確に返すため MAX_CHAT_LOG + 1 件取得し、超過分の有無で判定する。
+    // 超過分は表示・キャッシュには含めない。
     const { data, error } = await supabase
       .from(TABLE)
       .select(SELECT_COLUMNS)
       .eq('room_id', roomId)
       .eq('deleted', false)
       .order('uuid', { ascending: false })
-      .limit(MAX_CHAT_LOG);
+      .limit(MAX_CHAT_LOG + 1);
 
     if (error) {
       if (error.code === '401' || error.message.includes('JWT')) {
+        if (getCacheGeneration(roomId) === generation) {
+          snapshotHasMore.set(roomId, false);
+        }
         return getOfflineChatData(roomId);
       }
 
       throw new Error(`Supabase error: ${error.message} (${error.code})`);
     }
 
-    const chatData = (data ?? []).map(normalizeChat);
+    const rows = (data ?? []).map(normalizeChat);
+    const hasMore = rows.length > MAX_CHAT_LOG;
+    const chatData = hasMore ? rows.slice(0, MAX_CHAT_LOG) : rows;
     if (getCacheGeneration(roomId) === generation) {
       setCachedChatLogs(roomId, chatData);
+      snapshotHasMore.set(roomId, hasMore);
     }
     endPerf('loadChatLogs-network', startTime);
 
@@ -242,6 +260,7 @@ export function invalidateCache(roomId?: RoomId): void {
   if (roomId) {
     cache.delete(roomId);
     snapshotInflight.delete(roomId);
+    snapshotHasMore.delete(roomId);
     bumpCacheGeneration(roomId);
     for (const key of pagingInflight.keys()) {
       if (key.startsWith(`${roomId}|`)) {
@@ -259,6 +278,7 @@ export function invalidateCache(roomId?: RoomId): void {
   const roomsToInvalidate = new Set<RoomId>([
     ...cache.keys(),
     ...snapshotInflight.keys(),
+    ...snapshotHasMore.keys(),
     ...cacheGeneration.keys(),
   ]);
   for (const key of pagingInflight.keys()) {
@@ -270,6 +290,7 @@ export function invalidateCache(roomId?: RoomId): void {
 
   cache.clear();
   snapshotInflight.clear();
+  snapshotHasMore.clear();
   pagingInflight.clear();
   pagingHasMore.clear();
   for (const room of roomsToInvalidate) {
@@ -317,6 +338,14 @@ export function getPagingHasMore(
   return pagingHasMore.get(getPagingKey(roomId, offset, limit));
 }
 
+/**
+ * canonical snapshot (offset=0) に追加で続きが存在するかどうか。
+ * 未取得 / オフラインフォールバック中は undefined を返す。
+ */
+export function getSnapshotHasMore(roomId: RoomId): boolean | undefined {
+  return snapshotHasMore.get(roomId);
+}
+
 export const chatLogResource = {
   loadChatLogs,
   loadChatLogsWithPaging,
@@ -326,4 +355,5 @@ export const chatLogResource = {
   applyOptimisticToCache,
   getCacheInfo,
   getPagingHasMore,
+  getSnapshotHasMore,
 };

--- a/src/features/chat/api/chatLogResource.ts
+++ b/src/features/chat/api/chatLogResource.ts
@@ -96,9 +96,10 @@ async function fetchSnapshot(
   return retryApiCall(async () => {
     if (!isOnline()) {
       endPerf('loadChatLogs-offline', startTime);
-      // オフラインフォールバック中は「続きがあるか」は不明なので false 扱い。
+      // オフラインフォールバック中は「続きがあるか」を確定できないため、エントリ自体を削除して
+      // getSnapshotHasMore は undefined を返す ("未取得" 状態) ようにする。
       if (getCacheGeneration(roomId) === generation) {
-        snapshotHasMore.set(roomId, false);
+        snapshotHasMore.delete(roomId);
       }
       return getOfflineChatData(roomId);
     }
@@ -115,8 +116,9 @@ async function fetchSnapshot(
 
     if (error) {
       if (error.code === '401' || error.message.includes('JWT')) {
+        // 認証 fallback も同様に「未取得」扱いにする (復旧後に再判定したいため)。
         if (getCacheGeneration(roomId) === generation) {
-          snapshotHasMore.set(roomId, false);
+          snapshotHasMore.delete(roomId);
         }
         return getOfflineChatData(roomId);
       }

--- a/src/features/chat/components/ChatLogList/ChatLogList.test.tsx
+++ b/src/features/chat/components/ChatLogList/ChatLogList.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import ChatLogList from './index';
 import type { Chat } from '@features/chat/types';
+import * as uuidUtils from '@shared/utils/uuid';
 
 vi.mock('@shared/utils/format', () => ({
   formatTime: (t: number) => `TIME(${t})`,
@@ -100,12 +101,11 @@ describe('ChatLogList', () => {
     expect(screen.getByText(`(TIME(${FIXED_NOW - 2000}))`)).toBeInTheDocument();
   });
 
-  it('does not recompute sliced chats when parent rerenders with the same chatLog reference', () => {
+  it('does not recompute sorted/sliced chats when parent rerenders with the same chatLog reference', () => {
+    // sortChatsByTime は ChatLogList の useMemo 内で呼ばれる。useMemo deps が
+    // [chatLog, windowRows] のため、参照不変な再 render では再実行されない。
+    const sortSpy = vi.spyOn(uuidUtils, 'sortChatsByTime');
     const stableChatLog = [...chatLog].reverse();
-    const sliceSpy = vi.fn((start?: number, end?: number) =>
-      Array.prototype.slice.call(stableChatLog, start, end)
-    );
-    stableChatLog.slice = sliceSpy as Chat[]['slice'];
 
     function Host() {
       const [tick, setTick] = useState(0);
@@ -120,10 +120,14 @@ describe('ChatLogList', () => {
     }
 
     render(<Host />);
-    expect(sliceSpy).toHaveBeenCalledTimes(1);
+    const initialCallCount = sortSpy.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThanOrEqual(1);
 
     fireEvent.click(screen.getByRole('button', { name: /rerender/ }));
 
-    expect(sliceSpy).toHaveBeenCalledTimes(1);
+    // 親の tick だけが変わって chatLog 参照は不変なので sort 呼び出しは増えない
+    expect(sortSpy.mock.calls.length).toBe(initialCallCount);
+
+    sortSpy.mockRestore();
   });
 });

--- a/src/features/chat/components/ChatLogList/ChatLogList.test.tsx
+++ b/src/features/chat/components/ChatLogList/ChatLogList.test.tsx
@@ -101,6 +101,68 @@ describe('ChatLogList', () => {
     expect(screen.getByText(`(TIME(${FIXED_NOW - 2000}))`)).toBeInTheDocument();
   });
 
+  it('sorts out-of-order chatLog by uuid v7 desc (newer first) before slicing by windowRows', () => {
+    // out-of-order: 古いメッセージが配列先頭、新しいメッセージが配列末尾
+    // (本実装が prepend を前提に sort をスキップする回帰を防ぐためのテスト)
+    const outOfOrder: Chat[] = [
+      {
+        uuid: '0191b8a0-0001-7000-8000-000000000001', // uuid v7: 古め
+        name: 'Older',
+        color: '#000',
+        message: 'OLDER_MESSAGE',
+        time: FIXED_NOW - 5000,
+        email: '',
+        ip: 'test-ip',
+        ua: 'test-ua',
+      },
+      {
+        uuid: '0191b8a0-9999-7000-8000-000000000002', // uuid v7: 新しめ
+        name: 'Newer',
+        color: '#000',
+        message: 'NEWER_MESSAGE',
+        time: FIXED_NOW - 1000,
+        email: '',
+        ip: 'test-ip',
+        ua: 'test-ua',
+      },
+    ];
+
+    // windowRows=1: sort 後の先頭 (= Newer) だけが描画される
+    render(<ChatLogList chatLog={outOfOrder} windowRows={1} />);
+    expect(screen.getByText('NEWER_MESSAGE')).toBeInTheDocument();
+    expect(screen.queryByText('OLDER_MESSAGE')).not.toBeInTheDocument();
+  });
+
+  it('falls back to time-desc sort when uuids are not v7 (e.g. temp- or test ids)', () => {
+    // uuid が temp-* / 単純 id のときは isUUIDv7 が false を返し、time-desc に fallback する
+    const outOfOrder: Chat[] = [
+      {
+        uuid: 'A',
+        name: 'Older',
+        color: '#000',
+        message: 'OLDER_MESSAGE',
+        time: FIXED_NOW - 5000,
+        email: '',
+        ip: 'test-ip',
+        ua: 'test-ua',
+      },
+      {
+        uuid: 'B',
+        name: 'Newer',
+        color: '#000',
+        message: 'NEWER_MESSAGE',
+        time: FIXED_NOW - 1000,
+        email: '',
+        ip: 'test-ip',
+        ua: 'test-ua',
+      },
+    ];
+
+    render(<ChatLogList chatLog={outOfOrder} windowRows={1} />);
+    expect(screen.getByText('NEWER_MESSAGE')).toBeInTheDocument();
+    expect(screen.queryByText('OLDER_MESSAGE')).not.toBeInTheDocument();
+  });
+
   it('does not recompute sorted/sliced chats when parent rerenders with the same chatLog reference', () => {
     // sortChatsByTime は ChatLogList の useMemo 内で呼ばれる。useMemo deps が
     // [chatLog, windowRows] のため、参照不変な再 render では再実行されない。

--- a/src/features/chat/components/ChatLogList/index.tsx
+++ b/src/features/chat/components/ChatLogList/index.tsx
@@ -1,6 +1,7 @@
 import { Fragment, memo, useMemo } from 'react';
 import type { Chat } from '@features/chat/types';
 import { useParticipants } from '@features/chat/hooks/useParticipants';
+import { sortChatsByTime } from '@shared/utils/uuid';
 import ParticipantsList from '../ParticipantsList';
 import ChatMessage from '../ChatMessage';
 import Divider from '../shared/Divider';
@@ -12,7 +13,10 @@ type Props = {
 };
 
 function ChatLogList({ chatLog, isLoading = false, windowRows }: Props) {
-  const chats = useMemo(() => chatLog.slice(0, windowRows), [chatLog, windowRows]);
+  // 表示境界で uuid v7 降順を保証する。useChatLog の reducer / mergeChat は
+  // 常に prepend するため通常時系列だが、out-of-order な realtime INSERT や
+  // 楽観的更新と保存済みログの合流順序に対する防御として明示的に sort する。
+  const chats = useMemo(() => sortChatsByTime(chatLog).slice(0, windowRows), [chatLog, windowRows]);
   const participants = useParticipants(chatLog);
 
   // 読み込み中の場合は専用のローディング表示を返す

--- a/src/features/chat/hooks/useChatHandlers.ts
+++ b/src/features/chat/hooks/useChatHandlers.ts
@@ -5,6 +5,7 @@ import {
   clearChatLogsByName,
   broadcastLookEvent,
   broadcastUnlookEvent,
+  createOptimisticChat,
 } from '@features/chat/api/chatApi';
 import { validateName } from '@features/chat/utils/validation';
 import { getClientIP, getUserAgent } from '@shared/utils/clientInfo';
@@ -13,23 +14,6 @@ import { isFortuneCommand, generateFortune } from '@features/chat/utils/fortuneB
 import type { Chat, ChatMetadata } from '@features/chat/types';
 import type { Dispatch, SetStateAction } from 'react';
 import type { RoomId } from '@features/chat/rooms';
-
-// 楽観的更新用のタイムスタンプを生成
-// 確実に先頭に表示されるよう、十分未来の時刻を使用
-function getOptimisticTimestamp(): number {
-  // 現在時刻 + 1年（確実に先頭に表示される）
-  return Date.now() + 365 * 24 * 60 * 60 * 1000;
-}
-
-// 楽観的更新用のチャットを作成（サーバー側でUUID v7とtimeを生成）
-function createOptimisticChat(baseChat: Omit<Chat, 'uuid' | 'time' | 'optimistic'>): Chat {
-  return {
-    ...baseChat,
-    uuid: `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`, // 一時UUID
-    time: getOptimisticTimestamp(),
-    optimistic: true, // 楽観的更新フラグを追加
-  };
-}
 
 export function useChatHandlers({
   roomId,

--- a/src/features/chat/hooks/useChatLog.test.ts
+++ b/src/features/chat/hooks/useChatLog.test.ts
@@ -125,4 +125,98 @@ describe('useChatLog', () => {
     expect(second).toHaveLength(1);
     expect(second[0]).toEqual(savedChat);
   });
+
+  describe('optimisticNonce による dedup (主キー)', () => {
+    it('nonce 一致なら他フィールドが違っても重複扱いで temp をスキップする', () => {
+      // legacy fallback キー (client_time / name / message) はすべて異なるが、
+      // nonce が一致するので saved 側と同一とみなして temp は prepend されない。
+      const savedChat: Chat = {
+        uuid: '018f-saved',
+        room_id: 'superbeginner',
+        name: 'Taro',
+        color: '#f00',
+        message: 'Hello',
+        time: 1_700_000_000_100,
+        client_time: 1_700_000_000_000,
+        optimistic: false,
+        ip: 'test-ip',
+        ua: 'test-ua',
+        metadata: { version: 1, optimisticNonce: 'nonce-abc' },
+      };
+      const tempChat: Chat = {
+        uuid: 'temp-xyz',
+        room_id: 'hajime', // different
+        name: 'Different', // different
+        color: '#000', // different
+        message: 'Different', // different
+        time: 999,
+        client_time: 555, // different (legacy fallback ならアンマッチになる)
+        optimistic: true,
+        ip: 'test-ip',
+        ua: 'test-ua',
+        metadata: { version: 1, optimisticNonce: 'nonce-abc' },
+      };
+
+      expect(reduceOptimisticChat([savedChat], tempChat)).toEqual([savedChat]);
+    });
+
+    it('nonce が異なれば同文面でも別チャットとして残す', () => {
+      const savedChat: Chat = {
+        uuid: '018f-saved',
+        room_id: 'superbeginner',
+        name: 'Taro',
+        color: '#f00',
+        message: 'Hello',
+        time: 1_700_000_000_100,
+        client_time: 1_700_000_000_000,
+        optimistic: false,
+        ip: 'test-ip',
+        ua: 'test-ua',
+        metadata: { version: 1, optimisticNonce: 'nonce-saved' },
+      };
+      const tempChat: Chat = {
+        ...savedChat,
+        uuid: 'temp-other',
+        time: 999,
+        optimistic: true,
+        metadata: { version: 1, optimisticNonce: 'nonce-temp' },
+      };
+
+      const next = reduceOptimisticChat([savedChat], tempChat);
+      expect(next).toEqual([tempChat, savedChat]);
+    });
+
+    it('fallback は両側で client_time が数値のときのみ成立する', () => {
+      // 旧データ (nonce なし) で client_time が両側 undefined だと、
+      // undefined === undefined で別メッセージ同士が誤一致してしまうのを防ぐ回帰テスト。
+      const savedChatNoClientTime: Chat = {
+        uuid: '018f-saved',
+        room_id: 'superbeginner',
+        name: 'Taro',
+        color: '#f00',
+        message: 'A',
+        time: 1_700_000_000_100,
+        optimistic: false,
+        ip: 'test-ip',
+        ua: 'test-ua',
+      };
+      const tempChatNoClientTime: Chat = {
+        uuid: 'temp-1',
+        room_id: 'superbeginner',
+        name: 'Taro',
+        color: '#f00',
+        message: 'B', // 全然違うメッセージ
+        time: 999,
+        optimistic: true,
+        ip: 'test-ip',
+        ua: 'test-ua',
+      };
+
+      // 両側 client_time が無いので fallback は不成立 → 別エントリとして prepend される
+      expect(reduceOptimisticChat([savedChatNoClientTime], tempChatNoClientTime)).toEqual([
+        tempChatNoClientTime,
+        savedChatNoClientTime,
+      ]);
+    });
+  });
 });

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -17,8 +17,11 @@ function isSavedMatchForTemp(saved: Chat, temp: Chat): boolean {
   }
 
   // 後方互換フォールバック: nonce 未付与の旧データ向け。
-  // 同一 client_time + name + message + room_id + color + system すべて一致したら同一とみなす。
-  // 短いメッセージ + 同名ユーザー同時送信で誤判定し得るが、nonce 付き経路に移行すれば解消する。
+  // client_time が両側で数値であることを必須にし、未設定行同士 (undefined === undefined) で
+  // 全く別メッセージが誤一致するのを防ぐ。
+  if (typeof temp.client_time !== 'number' || typeof saved.client_time !== 'number') {
+    return false;
+  }
   return (
     saved.optimistic !== true &&
     saved.client_time === temp.client_time &&

--- a/src/features/chat/hooks/useChatLog.ts
+++ b/src/features/chat/hooks/useChatLog.ts
@@ -9,6 +9,16 @@ import type { Chat } from '@features/chat/types';
 import { DEFAULT_ROOM_ID, type RoomId } from '@features/chat/rooms';
 
 function isSavedMatchForTemp(saved: Chat, temp: Chat): boolean {
+  // 強い鍵: optimisticNonce が両側で揃っていれば、ユーザー間 / メッセージ間衝突なく一致判定できる。
+  const tempNonce = temp.metadata?.optimisticNonce;
+  const savedNonce = saved.metadata?.optimisticNonce;
+  if (tempNonce && savedNonce) {
+    return saved.optimistic !== true && tempNonce === savedNonce;
+  }
+
+  // 後方互換フォールバック: nonce 未付与の旧データ向け。
+  // 同一 client_time + name + message + room_id + color + system すべて一致したら同一とみなす。
+  // 短いメッセージ + 同名ユーザー同時送信で誤判定し得るが、nonce 付き経路に移行すれば解消する。
   return (
     saved.optimistic !== true &&
     saved.client_time === temp.client_time &&
@@ -23,7 +33,7 @@ function isSavedMatchForTemp(saved: Chat, temp: Chat): boolean {
 export function reduceOptimisticChat(state: Chat[], chat: Chat): Chat[] {
   // temp UUID の楽観的更新は、対応する savedChat が
   // 既に base state に届いている場合は重複表示を避けるためスキップする
-  if (chat.uuid.startsWith('temp-') && typeof chat.client_time === 'number') {
+  if (chat.uuid.startsWith('temp-')) {
     const duplicate = state.some((c) => isSavedMatchForTemp(c, chat));
     if (duplicate) {
       return state;

--- a/src/features/chat/rooms.ts
+++ b/src/features/chat/rooms.ts
@@ -23,7 +23,6 @@ export const CHAT_ROOM_IDS = [
   'anime',
   'reborn',
   'monhan',
-  'kintama',
   'rozen',
   // ゲームチャット
   'game',
@@ -137,7 +136,6 @@ const ROOM_TITLES: Record<RoomId, string> = {
   anime: 'アニメチャット',
   reborn: 'リボーンチャット',
   monhan: 'モンスターハンターチャット',
-  kintama: '銀魂チャット',
   rozen: 'ローゼンメイデンチャット',
 
   game: 'ゲームチャット',
@@ -193,7 +191,10 @@ const ROOM_TITLES: Record<RoomId, string> = {
   durarara: 'デュラララ チャット',
   vocaloid: 'ボカロチャット',
   hetaria: 'ヘタリア チャット',
-  gintama: '銀魂なりきりチャット',
+  // `gintama` は /chat/gintama (通常: 銀魂チャット) と
+  // /chanari/gintama (なりきり用) で同一 ID を共有する。
+  // 表示ラベルは data.ts 側で section ごとに使い分ける。
+  gintama: '銀魂チャット',
   inazuma11: 'イナズマイレブンチャット',
   tenipri: 'テニプリチャット',
   touhou: '東方チャット',

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -100,6 +100,12 @@ export type ChatMetadata = {
   kind?: 'normal' | 'fortune' | 'admin';
   /** 管理人メッセージ用: 対象ユーザーの色（レガシーの orangered 等を再現） */
   userColor?: string;
+  /**
+   * 楽観的更新の重複表示防止用 nonce。
+   * `createOptimisticChat` が生成し、保存時にサーバーへ送られ、realtime INSERT で
+   * echo されて返るため、temp UUID と savedChat の同一性判定の強い鍵として使える。
+   */
+  optimisticNonce?: string;
 };
 
 // --- チャットメッセージ ---

--- a/src/features/chat/utils/normalizeMetadata.ts
+++ b/src/features/chat/utils/normalizeMetadata.ts
@@ -83,6 +83,10 @@ export function normalizeChatMetadata(input: unknown): ChatMetadata | undefined 
       result.userColor = input.userColor;
     }
 
+    if (typeof input.optimisticNonce === 'string') {
+      result.optimisticNonce = input.optimisticNonce;
+    }
+
     return result;
   } catch {
     return undefined;

--- a/src/features/top/components/header/Header.tsx
+++ b/src/features/top/components/header/Header.tsx
@@ -12,11 +12,17 @@ import './headerTheme.css';
  */
 function LogoBlock() {
   return (
-    <h1 className="ochat-header__logo-h1" aria-label="お気楽チャット">
+    <h1 className="ochat-header__logo-h1">
+      {/*
+        h1 / a に二重に accessible name を持たせないため:
+          - h1 は visible text ("お気楽チャット") からそのまま name を導出する
+            (URL 部分は aria-hidden 済み)
+          - a 側も aria-label は付けず、リンク先のヒントは title 属性で補う
+       */}
       <a
         className="ochat-header__logo"
         href={import.meta.env.BASE_URL}
-        aria-label="お気楽チャット トップへ"
+        title="お気楽チャットのトップへ"
       >
         <WingIcon className="ochat-header__logo-wing" />
         <span className="ochat-header__logo-texts">
@@ -43,6 +49,9 @@ type GuideMenuItem = {
 /**
  * ガイドメニュー。各項目は `<GuideIcon>` + テキストで構成され、
  * アイコンは装飾扱い（`aria-hidden="true"`）。
+ *
+ * 現状は遷移先未定のため `<button type="button">` でプレースホルダー描画する。
+ * 遷移先が確定したら `<a href={item.href}>` に戻す。
  */
 function GuideMenu({ items }: { items: readonly GuideMenuItem[] }) {
   return (
@@ -50,10 +59,10 @@ function GuideMenu({ items }: { items: readonly GuideMenuItem[] }) {
       <ul className="ochat-header__guide-list">
         {items.map((item) => (
           <li key={item.label} className="ochat-header__guide-item">
-            <a className="ochat-header__guide-link" href={item.href}>
+            <button type="button" className="ochat-header__guide-link" disabled>
               <GuideIcon kind={item.iconKind} className="ochat-header__guide-icon" />
               <span>{item.label}</span>
-            </a>
+            </button>
           </li>
         ))}
       </ul>
@@ -63,8 +72,12 @@ function GuideMenu({ items }: { items: readonly GuideMenuItem[] }) {
 
 /**
  * 1段目（プライマリ）タブ行。白〜薄グレーグラデ背景、アクティブ項目のみ青グラデ + 白文字。
+ *
+ * 現状は遷移先未定のため `<button type="button">` でプレースホルダー描画する。
+ * `activeIndex` は CSS によるビジュアル強調のみで用い、`aria-current` は付与しない
+ * (現在地を表すページが存在しないため)。
  */
-function PrimaryTabs({ items, activeIndex }: { items: readonly string[]; activeIndex: number }) {
+function PrimaryTabs({ items, activeIndex }: { items: readonly string[]; activeIndex?: number }) {
   return (
     <nav aria-label="メインナビゲーション" className="ochat-header__primary">
       <ul className="ochat-header__primary-list">
@@ -74,9 +87,9 @@ function PrimaryTabs({ items, activeIndex }: { items: readonly string[]; activeI
             'ochat-header__primary-tab' + (isActive ? ' ochat-header__primary-tab--active' : '');
           return (
             <li key={label} className="ochat-header__primary-item">
-              <a className={className} href="#" aria-current={isActive ? 'page' : undefined}>
+              <button type="button" className={className} disabled>
                 {label}
-              </a>
+              </button>
             </li>
           );
         })}
@@ -149,7 +162,8 @@ export function Header(): ReactNode {
         <LogoBlock />
         <GuideMenu items={guideItems} />
       </div>
-      <PrimaryTabs items={primaryNav} activeIndex={0} />
+      {/* PrimaryTabs は遷移先未定。activeIndex は渡さず、視覚的にも非アクティブで描画する */}
+      <PrimaryTabs items={primaryNav} />
       <div className="ochat-header__seam" aria-hidden="true" />
       <SecondaryTabs items={tabNav} activeIndex={0} />
     </header>

--- a/src/features/top/components/header/headerTheme.css
+++ b/src/features/top/components/header/headerTheme.css
@@ -183,6 +183,21 @@
   gap: 4px;
   color: var(--ochat-h-guide-link);
   text-decoration: none;
+  /* button 互換のリセット (現状は <button type="button" disabled> でも描画される) */
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.ochat-header__guide-link:disabled {
+  cursor: default;
+  /* disabled でも視覚はリンク同様に保つ */
+  opacity: 1;
+  color: var(--ochat-h-guide-link);
 }
 
 .ochat-header__guide-link:hover,
@@ -234,6 +249,13 @@
   font-weight: 500;
   color: var(--ochat-h-primary-tab-fg);
   text-decoration: none;
+  /* button 互換のリセット (現状は <button type="button" disabled> でも描画される) */
+  appearance: none;
+  border: 0;
+  margin: 0;
+  font-family: inherit;
+  width: 100%;
+  cursor: pointer;
   /* タブ上辺の丸み: レガシーデザインを踏襲 */
   border-radius: 5px 5px 0 0;
   background: linear-gradient(
@@ -246,6 +268,12 @@
     inset 1px 0 0 var(--ochat-h-primary-tab-divider),
     inset -1px 0 0 var(--ochat-h-primary-tab-divider),
     inset 0 -1px 0 var(--ochat-h-primary-tab-divider);
+}
+
+.ochat-header__primary-tab:disabled {
+  cursor: default;
+  opacity: 1;
+  color: var(--ochat-h-primary-tab-fg);
 }
 
 .ochat-header__primary-tab--active,

--- a/src/features/top/components/header/headerTheme.css
+++ b/src/features/top/components/header/headerTheme.css
@@ -200,8 +200,9 @@
   color: var(--ochat-h-guide-link);
 }
 
-.ochat-header__guide-link:hover,
-.ochat-header__guide-link:focus {
+/* disabled プレースホルダーには hover を当てない (操作不能なのに反応するように見えるのを防ぐ) */
+.ochat-header__guide-link:not(:disabled):hover,
+.ochat-header__guide-link:not(:disabled):focus {
   color: var(--ochat-h-guide-link-hover);
   text-decoration: underline;
 }
@@ -276,9 +277,14 @@
   color: var(--ochat-h-primary-tab-fg);
 }
 
+/*
+ * --active は明示的な「現在地」状態 (現状は付与する callsite なし)。
+ * hover/focus は disabled プレースホルダーには適用せず、
+ * 遷移可能なタブにのみアクティブ風の青グラデーションを当てる。
+ */
 .ochat-header__primary-tab--active,
-.ochat-header__primary-tab:hover,
-.ochat-header__primary-tab:focus {
+.ochat-header__primary-tab:not(:disabled):hover,
+.ochat-header__primary-tab:not(:disabled):focus {
   background: linear-gradient(
     to bottom,
     var(--ochat-h-primary-tab-active-bg-top) 0%,

--- a/src/features/top/data.ts
+++ b/src/features/top/data.ts
@@ -144,7 +144,8 @@ export const chatDirectoryGroups: ChatDirectoryGroup[] = [
       chanariRoom('アニメチャット', 'anime'),
       chanariRoom('リボーンチャット', 'reborn'),
       chanariRoom('モンスターハンターチャット', 'monhan'),
-      chanariRoom('銀魂チャット', 'gintama'),
+      // 通常チャットとして /chat/gintama に遷移する (なりきりは pickup 側で別途扱う)
+      room('銀魂チャット', 'gintama'),
       chanariRoom('ローゼンメイデンチャット', 'rozen'),
     ],
   },

--- a/src/pages/ChatLogPage.test.tsx
+++ b/src/pages/ChatLogPage.test.tsx
@@ -29,7 +29,8 @@ vi.mock('@features/chat/components/ChatLogList', () => ({
 vi.mock('@features/chat/api/chatApi', () => ({
   loadChatLogs: vi.fn().mockResolvedValue([mockChat]),
   loadInitialChatLogs: vi.fn().mockResolvedValue([mockChat]),
-  loadChatLogsWithPaging: vi.fn().mockResolvedValue({ data: [], hasMore: false }),
+  // ChatLogPage は loadChatLogsWithPaging の戻り値で初期表示を組み立てる
+  loadChatLogsWithPaging: vi.fn().mockResolvedValue({ data: [mockChat], hasMore: false }),
   getCacheInfo: vi.fn().mockReturnValue({ cached: false }),
 }));
 

--- a/src/pages/ChatLogPage.tsx
+++ b/src/pages/ChatLogPage.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState, useEffect, useCallback } from 'react';
 import ChatLogList from '@features/chat/components/ChatLogList';
-import { loadInitialChatLogs, loadChatLogsWithPaging } from '@features/chat/api/chatApi';
+import { loadChatLogsWithPaging } from '@features/chat/api/chatApi';
 import { usePreloadChatLogs } from '@features/chat/hooks/usePreloadChatLogs';
 import Button from '@shared/components/Button';
 import type { Chat } from '@features/chat/types';
@@ -19,17 +19,16 @@ export default function ChatLogPage() {
   const loadInitialData = useCallback(async () => {
     setIsLoading(true);
     try {
-      // プリロードされたデータがあれば使用
-      let initialData: Chat[];
+      // プリロード（usePreloadChatLogs 内で `loadInitialChatLogs` が走り、
+      // chatLogResource のキャッシュに canonical snapshot が積まれている）。
+      // 結果は破棄して、hasMore を正確に返す `loadChatLogsWithPaging` 経由で再取得する。
       if (preloadPromise) {
-        initialData = await preloadPromise;
-      } else {
-        // 初回は少量のデータを素早く読み込み
-        initialData = await loadInitialChatLogs(DEFAULT_ROOM_ID, Math.min(windowRows, 100));
+        await preloadPromise;
       }
-
-      setChatLog(initialData);
-      setHasMore(initialData.length >= Math.min(windowRows, 100));
+      const limit = Math.min(windowRows, 100);
+      const result = await loadChatLogsWithPaging(DEFAULT_ROOM_ID, limit, 0, true);
+      setChatLog(result.data);
+      setHasMore(result.hasMore);
     } catch (error) {
       console.error('Failed to load chat logs:', error);
     } finally {


### PR DESCRIPTION
Copilot Review への対応

  20 件のうち、高優先 4 件 + 中優先 6 件 を以下 6 コミットで対応しました。低優先 10 件は別途対応とします（理由はスレッド末尾）。

  対応一覧

  Review: #1 kintama 到達不能 + 俗語
  対応コミット: 09debdb
  概要: kintama を削除し、アニメ section の「銀魂チャット」を gintama 側へ寄せた。gintama ID は /chat/ と /chanari/
    両方の経路で共用（ラベルは data.ts で section ごとに使い分け、ROOM_TITLES は「銀魂チャット」に統一）。
  ────────────────────────────────────────
  Review: #2 hasMore が常に true
  対応コミット: 29dd615
  概要: chatLogResource.fetchSnapshot を MAX_CHAT_LOG + 1 件取得に変更し snapshotHasMore: Map<RoomId, boolean>
    で記録。loadChatLogsWithPaging(offset=0) は snapshot.length > limit || snapshotHasMoreFlag で判定。ChatLogPage
    も新経路に統一。chatApi.test.ts に capped (101 行) / under-cap (80 行) の 2 ケース追加。
  ────────────────────────────────────────
  Review: #3 ChatLogList が sort しない
  対応コミット: be0f899
  概要: 表示境界で sortChatsByTime を useMemo 内で適用し、out-of-order な realtime INSERT に対する防御を復活。既存メモ化テストは
    vi.spyOn(sortChatsByTime) に書き換え。
  ────────────────────────────────────────
  Review: #5 isSavedMatchForTemp の dedup キーが弱い
  対応コミット: 29dd615
  概要: ChatMetadata.optimisticNonce を新設し createOptimisticChat で crypto.randomUUID()（fallback あり）を付与。normalizeChatMetadata

    も保持。isSavedMatchForTemp は nonce 優先 + 旧ロジック fallback の 2 段判定に。
  ────────────────────────────────────────
  Review: #6 useChanariSettings が roomId 再 hydrate しない
  対応コミット: 2fa4b08
  概要: useRef で前回 roomId を保持し、変化時のみ loadDraft(roomId) を再実行（初回は useState initializer 任せ）。
  ────────────────────────────────────────
  Review: #8 <h1> と <a> の二重 aria-label
  対応コミット: 55bb60f
  概要: <h1> の aria-label を削除し visible text に任せ、<a> も aria-label を撤去して title で hover ヒント。heading の accessible name

    競合を解消。
  ────────────────────────────────────────
  Review: #9 PrimaryTabs / GuideMenu の href="#" + activeIndex=0 固定
  対応コミット: 55bb60f
  概要: <a href="#"> を <button type="button" disabled> に置換、aria-current の emission と activeIndex={0} ハードコードを撤去。
  ────────────────────────────────────────
  Review: #10 chanari.com ハードコード外部リンク
  対応コミット: 55bb60f
  概要: backHref={import.meta.env.BASE_URL}（in-app top）に変更、helpHref を optional 化して未指定時は非描画。ChanariTopHeader は
    external URL を渡せば従来通り target="_blank" を付与する汎用化。
  ────────────────────────────────────────
  Review: #12 + #13 broadcast / postgres channel の leak と StrictMode 衝突
  対応コミット: 29dd615
  概要: refCount ベースの postgresEntries / broadcastEntries registry を導入。room 単位で 1 channel を共有、listener Set が空になったら

    supabase.removeChannel で破棄。
  ────────────────────────────────────────
  Review: #14 clearChatLogs だけ hard delete
  対応コミット: 29dd615
  概要: .delete() を .update({ deleted: true }).eq('deleted', false) に変更し、clearChatLogsByName と SELECT 側 (.eq('deleted', false))

    と論理削除方針を統一。room 全消去も復旧可能に。

  検証

  - pnpm typecheck → pass
  - pnpm test → 173 passed (173)
  - 各コミットで lefthook の eslint / typecheck / vitest-staged フックを通過

  低優先のため別 PR / 後続対応とした 10 件

  - #4 SPA router が <a> を傍受しない → 仕様（GitHub Pages 404 fallback でフルリロード復元される）。doc に明記済み。
  - #7 roomCountsApi の「ユニーク参加者数」が表示名ベース → 既に docstring で ユニーク発言者数
  と明記。匿名チャットの性質上、これ以上厳密にしにくい。
  - #11 routing utils 重複 → 実害なし。@shared/utils/basePath 化は別途。
  - #15 saveChatLogOptimistic の 3 列 SELECT → 設計。ARCHITECTURE.md §7.2 で「サーバー権威は uuid/room_id/time のみ」と明記済み。
  - #16 getRoomIdFromPagingKey の cast → 単一生成源で実害なし。
  - #17 canUseLocalStorage の毎回 I/O → 微小。draft 保存頻度的に影響は無視できる。
  - #18 index.html slice(0, -1) edge case → GitHub Pages が / を強制するので実害なし。
  - #19 DB room_id の CHECK / FK なし → アプリ側 isEnabledRoomId で防御済み。新ルーム追加の機動性のため schema-less 維持。
  - #20 useState 初期化で window を触る → 当面 SSR / Node renderer 計画なし。

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  
This pull request includes several improvements and fixes across the documentation and the Chanari chat feature, focusing on usability, correctness, and maintainability. The most significant changes are grouped below by theme.

### Chanari Chat Feature Improvements

* Updated the `ChanariTopHeader` component to make the `helpHref` prop optional and to only open external links in a new tab; internal links now open in the same tab. Also, the back link now uses the app's base URL instead of a hardcoded external URL. (`src/features/chanari-chat/ChanariChatPage.tsx`, `src/features/chanari-chat/components/ChanariTopHeader/index.tsx`) [[1]](diffhunk://#diff-06e3849b083b97b45ed8cd988920330896aee3fa4dfd98d05444cf9775dd81e2L62-R62) [[2]](diffhunk://#diff-73c166de5fc2ce3a5e666f9b2556c46b2627adddb70d7e2d250bb2ca6c7953a3L3-R44)
* Enhanced the `useChanariSettings` hook to rehydrate settings when the `roomId` changes, preventing settings from leaking between rooms. (`src/features/chanari-chat/hooks/useChanariSettings.ts`) [[1]](diffhunk://#diff-eef12f2a0641013aa60e35940571b1b1312d6d6848c93560ae2db726e8172bcdL1-R1) [[2]](diffhunk://#diff-eef12f2a0641013aa60e35940571b1b1312d6d6848c93560ae2db726e8172bcdR13-R22)

### Chat Log Paging and Cache Logic

* Improved the paging logic in `chatApi.loadChatLogsWithPaging` to better detect when there are more chat logs available in the database than the current snapshot, ensuring the `hasMore` flag is accurate even when the snapshot is capped. Added corresponding tests to verify both capped and uncapped cases. (`src/features/chat/api/chatApi.ts`, `src/features/chat/api/chatApi.test.ts`) [[1]](diffhunk://#diff-b4dce2cdb9071e7bf5fc5e5f386e33378fcf896377434157db637e8222d7f515R17) [[2]](diffhunk://#diff-b4dce2cdb9071e7bf5fc5e5f386e33378fcf896377434157db637e8222d7f515R87-R94) [[3]](diffhunk://#diff-c717ebf36c66a682bed7474f8442dd07e29c9763db30e0f8db0265d38887d041L54-R85)
* Changed the `clearChatLogs` function to use logical deletion (setting a `deleted` flag) instead of hard deletion, aligning its behavior with `clearChatLogsByName` and ensuring consistency across the codebase. (`src/features/chat/api/chatApi.ts`)
* Added an `optimisticNonce` to optimistic chat messages to prevent duplicate display and improve identification of matching messages between client and server events. (`src/features/chat/api/chatApi.ts`)

### Documentation and Test Maintenance

* Fixed table formatting and improved alignment in `ARCHITECTURE.md` and `TEST_STRATEGY.md` for better readability and accuracy. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L192-R192) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L205-R205) [[3]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L315-R315) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L376-R376) [[5]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L412-R412) [[6]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L513-R513) [[7]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L549-R549) [[8]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L559-R559) [[9]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L737-R737) [[10]](diffhunk://#diff-af39a6237e8e23f477f0f4b440657d7545adf6bc4739ae3b6fc0ec032a00fd7bL14-R14) [[11]](diffhunk://#diff-af39a6237e8e23f477f0f4b440657d7545adf6bc4739ae3b6fc0ec032a00fd7bL97-R97)
  
  CopilotReviewは日本語でレビューしてください