### PR TITLE
feat: 全部屋まとめチャット (Chat-All) を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ coverage/
 .env.*
 !*.example
 
+# Supabase (CLI のローカル状態。リンク先キャッシュ等は各自ローカルで生成・共有しない)
+supabase/.temp/
+supabase/.branches/
+# config.toml / migrations / functions は追跡対象（共有する）
+
 # その他
 logs/
 settings.local.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,13 @@ packages:
       }
     engines: { node: '>=6.9.0' }
 
+  '@babel/code-frame@7.29.7':
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: '>=6.9.0' }
+
   '@babel/compat-data@7.29.3':
     resolution:
       {
@@ -267,6 +274,13 @@ packages:
       }
     engines: { node: '>=6.9.0' }
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+      }
+    engines: { node: '>=6.9.0' }
+
   '@babel/helper-validator-option@7.27.1':
     resolution:
       {
@@ -293,6 +307,13 @@ packages:
     resolution:
       {
         integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/runtime@7.29.7':
+    resolution:
+      {
+        integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
       }
     engines: { node: '>=6.9.0' }
 
@@ -1290,7 +1311,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution:
@@ -1300,7 +1320,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution:
@@ -1310,7 +1329,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution:
@@ -1320,7 +1338,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution:
@@ -1330,7 +1347,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution:
@@ -1340,7 +1356,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution:
@@ -1350,7 +1365,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution:
@@ -1360,7 +1374,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution:
@@ -1481,7 +1494,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution:
@@ -1490,7 +1502,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution:
@@ -1499,7 +1510,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution:
@@ -1508,7 +1518,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution:
@@ -1517,7 +1526,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution:
@@ -1526,7 +1534,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution:
@@ -1535,7 +1542,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution:
@@ -1544,7 +1550,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution:
@@ -1630,7 +1635,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution:
@@ -1640,7 +1644,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution:
@@ -1650,7 +1653,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution:
@@ -1660,7 +1662,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution:
@@ -1670,7 +1671,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution:
@@ -1680,7 +1680,6 @@ packages:
     engines: { node: '>= 10.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution:
@@ -1811,7 +1810,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution:
@@ -1821,7 +1819,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution:
@@ -1831,7 +1828,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution:
@@ -1841,7 +1837,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution:
@@ -1851,7 +1846,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution:
@@ -1861,7 +1855,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution:
@@ -1971,7 +1964,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution:
@@ -1980,7 +1972,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution:
@@ -1989,7 +1980,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution:
@@ -1998,7 +1988,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution:
@@ -2007,7 +1996,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution:
@@ -2016,7 +2004,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution:
@@ -2025,7 +2012,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution:
@@ -2034,7 +2020,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution:
@@ -2043,7 +2028,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution:
@@ -2052,7 +2036,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution:
@@ -2061,7 +2044,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution:
@@ -2070,7 +2052,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution:
@@ -2079,7 +2060,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution:
@@ -2390,7 +2370,6 @@ packages:
     engines: { node: '>= 20' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution:
@@ -2400,7 +2379,6 @@ packages:
     engines: { node: '>= 20' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution:
@@ -2410,7 +2388,6 @@ packages:
     engines: { node: '>= 20' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution:
@@ -2420,7 +2397,6 @@ packages:
     engines: { node: '>= 20' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution:
@@ -4931,7 +4907,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution:
@@ -4941,7 +4916,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution:
@@ -4951,7 +4925,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution:
@@ -4961,7 +4934,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution:
@@ -7221,6 +7193,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
@@ -7281,6 +7259,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.29.2':
@@ -7293,6 +7273,8 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -8576,8 +8558,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,499 +3,499 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.okiraku.chat/</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat-log</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/superbeginner</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hajime</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/ofall</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/yume</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/elementary</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/juniorhighschool</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/juniorhighschool3</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/highschool</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/daigaku</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/10generations</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/20generations</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/30generations</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/umaimise</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/osare</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/news</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/jinsei</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/anime</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/reborn</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/monhan</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/rozen</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/game</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/pazudora</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/3ds</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/natsuyasumi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hanabi-taikai</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/haruyasumi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_kantoh</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_hok_touho</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_toukai</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_kansai</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_chu_shi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/area_kyu_oki</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/music</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/dance</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/travel</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/darts</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/tabletennis</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/omikuji</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/mico</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/puchi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/gyamikuji</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/meruhen1</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/meruhen2</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/colorful</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hoshi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/karaoke</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/karaoke2</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/sports</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hoshizora</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/ohirune</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/kakifry</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/vip</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hajime-old</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/mattari</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/wai2</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/joren</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/shouchu</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/20dai</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/30dai</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/battle</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/2shot</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/com_sb</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/durarara</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/vocaloid</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/hetaria</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/gintama</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/inazuma11</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/tenipri</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/touhou</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/basara</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/inazuma11go</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/bakatesu</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/working</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/akb48</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/majutu</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/bleach</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/kuroshitsuji</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/keion</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/dgrayman</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/haruhi</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.okiraku.chat/chat/railgun</loc>
-    <lastmod>2026-05-17</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -12,7 +12,7 @@
 import { writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CHAT_ROOMS, CHAT_ROOM_IDS } from '../src/features/chat/rooms.ts';
+import { CHAT_ROOMS, getListableRoomIds } from '../src/features/chat/rooms.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ORIGIN = 'https://www.okiraku.chat';
@@ -23,11 +23,13 @@ type Entry = { loc: string; changefreq: string; priority: string };
 const entries: Entry[] = [
   { loc: `${ORIGIN}/`, changefreq: 'daily', priority: '1.0' },
   { loc: `${ORIGIN}/chat-log`, changefreq: 'weekly', priority: '0.3' },
-  ...CHAT_ROOM_IDS.filter((id) => CHAT_ROOMS[id].enabled).map((id) => ({
-    loc: `${ORIGIN}/chat/${id}`,
-    changefreq: 'daily',
-    priority: '0.7',
-  })),
+  ...getListableRoomIds()
+    .filter((id) => CHAT_ROOMS[id].enabled)
+    .map((id) => ({
+      loc: `${ORIGIN}/chat/${id}`,
+      changefreq: 'daily',
+      priority: '0.7',
+    })),
 ];
 
 const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import type { RouteMatch } from '@features/chat/routing';
 import { matchChanariRoute } from '@features/chanari-chat/routing';
 import type { ChanariRouteMatch } from '@features/chanari-chat/routing';
 import ChatRoute from './routes/ChatRoute';
+import AllRoomsRoute from './routes/AllRoomsRoute';
 import TopRoute from './routes/TopRoute';
 import ChanariRoute from './routes/ChanariRoute';
 import NotFoundRoute from './routes/NotFoundRoute';
@@ -116,7 +117,8 @@ export default function App() {
   return (
     <>
       {route.type === 'top' && <TopRoute />}
-      {route.type === 'chat-room' && <ChatRoute roomId={route.roomId} />}
+      {route.type === 'chat-room' &&
+        (route.roomId === 'all' ? <AllRoomsRoute /> : <ChatRoute roomId={route.roomId} />)}
       {/*
         key={roomId}: ChanariChatPage は useState(settings.X) で入力 state を初期化するため
         roomId 変化時に remount しないと別 room の入力 / 下書きが残ってしまう。

--- a/src/features/chat/api/chatAllApi.ts
+++ b/src/features/chat/api/chatAllApi.ts
@@ -3,7 +3,8 @@ import { supabase } from '@shared/supabaseClient';
 import { normalizeChat } from '../utils/normalizeMetadata';
 
 const TABLE = 'chats';
-const SELECT_COLUMNS = 'uuid,room_id,name,color,message,time,system,email,metadata';
+// email は全部屋ビューで deleted=true 行も表示するため、個人情報露出防止で除外する
+const SELECT_COLUMNS = 'uuid,room_id,name,color,message,time,system,metadata';
 
 /**
  * 横断読み込み: room_id フィルタなし・deleted 無視・uuid 降順・limit 件。
@@ -26,8 +27,12 @@ export async function loadAllRoomsChatLogs(limit = 200): Promise<Chat[]> {
 /**
  * 横断購読: room_id フィルタなしの単一 channel で全 INSERT を受ける。
  * 既存の subscribeChatLogs は一切変更しない。
+ * onError は CHANNEL_ERROR / TIMED_OUT / CLOSED 時に呼ばれる。
  */
-export function subscribeAllRoomsChatLogs(callback: (chat: Chat) => void): {
+export function subscribeAllRoomsChatLogs(
+  callback: (chat: Chat) => void,
+  onError?: () => void
+): {
   unsubscribe: () => void;
 } {
   const channel = supabase
@@ -35,7 +40,11 @@ export function subscribeAllRoomsChatLogs(callback: (chat: Chat) => void): {
     .on('postgres_changes', { event: 'INSERT', schema: 'public', table: TABLE }, (payload) => {
       callback(normalizeChat(payload.new));
     })
-    .subscribe();
+    .subscribe((status) => {
+      if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+        onError?.();
+      }
+    });
 
   return {
     unsubscribe() {

--- a/src/features/chat/api/chatAllApi.ts
+++ b/src/features/chat/api/chatAllApi.ts
@@ -1,0 +1,45 @@
+import type { Chat } from '@features/chat/types';
+import { supabase } from '@shared/supabaseClient';
+import { normalizeChat } from '../utils/normalizeMetadata';
+
+const TABLE = 'chats';
+const SELECT_COLUMNS = 'uuid,room_id,name,color,message,time,system,email,metadata';
+
+/**
+ * 横断読み込み: room_id フィルタなし・deleted 無視・uuid 降順・limit 件。
+ * 既存の chatLogResource キャッシュを一切経由しない別経路。
+ */
+export async function loadAllRoomsChatLogs(limit = 200): Promise<Chat[]> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select(SELECT_COLUMNS)
+    .order('uuid', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to load all rooms chat logs: ${error.message}`);
+  }
+
+  return (data ?? []).map(normalizeChat);
+}
+
+/**
+ * 横断購読: room_id フィルタなしの単一 channel で全 INSERT を受ける。
+ * 既存の subscribeChatLogs は一切変更しない。
+ */
+export function subscribeAllRoomsChatLogs(callback: (chat: Chat) => void): {
+  unsubscribe: () => void;
+} {
+  const channel = supabase
+    .channel('chats-postgres-all')
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: TABLE }, (payload) => {
+      callback(normalizeChat(payload.new));
+    })
+    .subscribe();
+
+  return {
+    unsubscribe() {
+      supabase.removeChannel(channel);
+    },
+  };
+}

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -20,6 +20,22 @@ export { prefetchChatLogs, getSnapshotHasMore } from './chatLogResource';
 
 const TABLE = 'chats';
 
+// Edge Function 共通呼び出し。ip / ua はサーバー側で設定するため payload に含めない。
+async function invokeSaveChat(payload: {
+  room_id: RoomId;
+  name: string;
+  color: string;
+  message: string;
+  system?: boolean;
+  email?: string | null;
+  metadata?: Chat['metadata'];
+}): Promise<{ uuid: string; room_id: RoomId; time: number }> {
+  const { data, error } = await supabase.functions.invoke('save-chat', { body: payload });
+  if (error) throw new Error(`Failed to save chat: ${error.message}`);
+  if ((data as any)?.error) throw new Error(`Failed to save chat: ${(data as any).error}`);
+  return data as { uuid: string; room_id: RoomId; time: number };
+}
+
 // UUID v7最適化設定
 // Supabase側でUUID v7を主キーとして自動生成し、時系列順序性を活用
 
@@ -126,7 +142,7 @@ export async function saveChatLogOptimistic(
   startPerf();
 
   return retryApiCall(async () => {
-    const body = {
+    const result = await invokeSaveChat({
       room_id: roomId,
       name: chat.name,
       color: chat.color,
@@ -134,96 +150,59 @@ export async function saveChatLogOptimistic(
       system: chat.system,
       email: chat.email,
       metadata: chat.metadata ?? null,
-      // ip / ua は Edge Function がリクエストヘッダから取得するため送信しない
-    };
-
-    const { data, error } = await supabase.functions.invoke('save-chat', { body });
-
-    if (error) {
-      throw new Error(`Failed to save chat: ${error.message}`);
-    }
+    });
 
     Promise.resolve().then(() => invalidateCache(roomId));
     endPerf('saveChatLogOptimistic');
 
     return {
       ...chat,
-      uuid: (data as any).uuid,
-      room_id: (data as any).room_id ?? roomId,
-      time: (data as any).time,
+      uuid: result.uuid,
+      room_id: result.room_id ?? roomId,
+      time: result.time,
       optimistic: false,
     };
   });
 }
 
-// 従来の互換性維持版
+// 従来の互換性維持版（Edge Function 経由で ip/ua をサーバー確定）
 export async function saveChatLog(roomId: RoomId = DEFAULT_ROOM_ID, chat: Chat): Promise<Chat> {
   startPerf();
 
   return retryApiCall(async () => {
-    const sanitized = {
-      // idは除外 - Supabaseでサーバー側のUUID v7を生成
+    const result = await invokeSaveChat({
       room_id: roomId,
       name: chat.name,
       color: chat.color,
       message: chat.message,
-      // timeは除外 - Supabaseでサーバー側のタイムスタンプを使用
       system: chat.system,
       email: chat.email,
-      ip: chat.ip,
-      ua: chat.ua,
       metadata: chat.metadata ?? null,
-    };
+    });
 
-    // insertして、必要な列のみを取得（パフォーマンス向上）
-    const { data, error } = await supabase
-      .from(TABLE)
-      .insert(sanitized)
-      .select('uuid,room_id,name,color,message,time,system,email,ip,ua,metadata')
-      .single();
-
-    if (error) {
-      throw new Error(`Failed to save chat: ${error.message}`);
-    }
-
-    // 新しいチャットが追加されたらキャッシュを無効化
     invalidateCache(roomId);
-
     endPerf('saveChatLog');
 
-    // サーバー側のタイムスタンプを含むデータを返す
-    return data as Chat;
+    return { ...chat, uuid: result.uuid, room_id: result.room_id ?? roomId, time: result.time };
   });
 }
 
-// Fire-and-forget版（レスポンスを待たない最高速版）
+// Fire-and-forget版（Edge Function 経由・レスポンスを待たない）
 export function saveChatLogFireAndForget(chat: Chat): Promise<void> {
-  const sanitized = {
-    // idは除外 - Supabaseでサーバー側のUUID v7を生成
-    room_id: chat.room_id ?? DEFAULT_ROOM_ID,
+  const roomId = chat.room_id ?? DEFAULT_ROOM_ID;
+
+  void invokeSaveChat({
+    room_id: roomId,
     name: chat.name,
     color: chat.color,
     message: chat.message,
     system: chat.system,
     email: chat.email,
-    ip: chat.ip,
-    ua: chat.ua,
     metadata: chat.metadata ?? null,
-  };
+  })
+    .then(() => invalidateCache(roomId))
+    .catch((err: unknown) => console.error('Background chat save failed:', err));
 
-  // バックグラウンドでの非同期実行
-  (async () => {
-    try {
-      await supabase.from(TABLE).insert(sanitized);
-
-      // 成功時のみキャッシュを無効化
-      invalidateCache(chat.room_id ?? DEFAULT_ROOM_ID);
-    } catch (error) {
-      console.error('Background chat save failed:', error);
-    }
-  })();
-
-  // 即座に解決
   return Promise.resolve();
 }
 

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -28,12 +28,23 @@ async function invokeSaveChat(payload: {
   message: string;
   system?: boolean;
   email?: string | null;
-  metadata?: Chat['metadata'];
+  metadata?: Chat['metadata'] | null;
 }): Promise<{ uuid: string; room_id: RoomId; time: number }> {
   const { data, error } = await supabase.functions.invoke('save-chat', { body: payload });
   if (error) throw new Error(`Failed to save chat: ${error.message}`);
-  if ((data as any)?.error) throw new Error(`Failed to save chat: ${(data as any).error}`);
-  return data as { uuid: string; room_id: RoomId; time: number };
+  const result: unknown = data;
+  if (typeof result === 'object' && result !== null && 'error' in result) {
+    throw new Error(`Failed to save chat: ${String((result as { error: unknown }).error)}`);
+  }
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    typeof (result as { uuid?: unknown }).uuid !== 'string' ||
+    typeof (result as { time?: unknown }).time !== 'number'
+  ) {
+    throw new Error('Failed to save chat: unexpected response from Edge Function');
+  }
+  return result as { uuid: string; room_id: RoomId; time: number };
 }
 
 // UUID v7最適化設定
@@ -183,7 +194,7 @@ export async function saveChatLog(roomId: RoomId = DEFAULT_ROOM_ID, chat: Chat):
     invalidateCache(roomId);
     endPerf('saveChatLog');
 
-    return { ...chat, uuid: result.uuid, room_id: result.room_id ?? roomId, time: result.time };
+    return { ...chat, uuid: result.uuid, room_id: result.room_id ?? roomId, time: result.time, optimistic: false };
   });
 }
 

--- a/src/features/chat/api/chatApi.ts
+++ b/src/features/chat/api/chatApi.ts
@@ -68,46 +68,6 @@ function getOfflineChatData(roomId: RoomId): Chat[] {
   return mockChatData.map((chat) => ({ ...chat, room_id: roomId }));
 }
 
-// INSERT は save-chat Edge Function に集約する。
-// ip / ua はクライアントから送らず、Edge がリクエストヘッダ（x-forwarded-for /
-// user-agent）から確定する。uuid / time / deleted は DB 既定値に委ねる。
-// metadata はそのまま渡し、optimisticNonce の Realtime echo を維持する。
-type SaveChatPayload = {
-  room_id: RoomId;
-  name: string;
-  color: string;
-  message: string;
-  system?: boolean;
-  email?: string;
-  metadata: Chat['metadata'] | null;
-};
-
-function buildSaveChatPayload(roomId: RoomId, chat: Chat): SaveChatPayload {
-  return {
-    room_id: roomId,
-    name: chat.name,
-    color: chat.color,
-    message: chat.message,
-    system: chat.system,
-    email: chat.email,
-    metadata: chat.metadata ?? null,
-  };
-}
-
-// save-chat を呼び出し、サーバー生成の { uuid, room_id, time } を返す。
-async function invokeSaveChat(
-  payload: SaveChatPayload
-): Promise<{ uuid: string; room_id: RoomId; time: number }> {
-  const { data, error } = await supabase.functions.invoke('save-chat', { body: payload });
-  if (error) {
-    throw new Error(`Failed to save chat: ${error.message}`);
-  }
-  if (data?.error) {
-    throw new Error(`Failed to save chat: ${data.error}`);
-  }
-  return data as { uuid: string; room_id: RoomId; time: number };
-}
-
 export async function loadChatLogs(
   roomId: RoomId = DEFAULT_ROOM_ID,
   useCache = true
@@ -158,6 +118,7 @@ export async function loadInitialChatLogs(
 }
 
 // 楽観的更新用の高速バージョン
+// INSERT は save-chat Edge Function 経由（ip/ua をサーバー側で設定し、RLS を通過）
 export async function saveChatLogOptimistic(
   roomId: RoomId = DEFAULT_ROOM_ID,
   chat: Chat
@@ -165,20 +126,31 @@ export async function saveChatLogOptimistic(
   startPerf();
 
   return retryApiCall(async () => {
-    // ip / ua はクライアントから送らず Edge がヘッダから確定する
-    const data = await invokeSaveChat(buildSaveChatPayload(roomId, chat));
+    const body = {
+      room_id: roomId,
+      name: chat.name,
+      color: chat.color,
+      message: chat.message,
+      system: chat.system,
+      email: chat.email,
+      metadata: chat.metadata ?? null,
+      // ip / ua は Edge Function がリクエストヘッダから取得するため送信しない
+    };
 
-    // キャッシュ無効化を非同期で実行（ブロッキングしない）
+    const { data, error } = await supabase.functions.invoke('save-chat', { body });
+
+    if (error) {
+      throw new Error(`Failed to save chat: ${error.message}`);
+    }
+
     Promise.resolve().then(() => invalidateCache(roomId));
-
     endPerf('saveChatLogOptimistic');
 
-    // サーバー側のUUID v7とタイムスタンプを使用して完全なChatオブジェクトを返す
     return {
       ...chat,
-      uuid: data.uuid, // サーバー生成のUUID v7
-      room_id: data.room_id ?? roomId,
-      time: data.time,
+      uuid: (data as any).uuid,
+      room_id: (data as any).room_id ?? roomId,
+      time: (data as any).time,
       optimistic: false,
     };
   });
@@ -189,36 +161,63 @@ export async function saveChatLog(roomId: RoomId = DEFAULT_ROOM_ID, chat: Chat):
   startPerf();
 
   return retryApiCall(async () => {
-    // ip / ua はクライアントから送らず Edge がヘッダから確定する
-    const data = await invokeSaveChat(buildSaveChatPayload(roomId, chat));
+    const sanitized = {
+      // idは除外 - Supabaseでサーバー側のUUID v7を生成
+      room_id: roomId,
+      name: chat.name,
+      color: chat.color,
+      message: chat.message,
+      // timeは除外 - Supabaseでサーバー側のタイムスタンプを使用
+      system: chat.system,
+      email: chat.email,
+      ip: chat.ip,
+      ua: chat.ua,
+      metadata: chat.metadata ?? null,
+    };
+
+    // insertして、必要な列のみを取得（パフォーマンス向上）
+    const { data, error } = await supabase
+      .from(TABLE)
+      .insert(sanitized)
+      .select('uuid,room_id,name,color,message,time,system,email,ip,ua,metadata')
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to save chat: ${error.message}`);
+    }
 
     // 新しいチャットが追加されたらキャッシュを無効化
     invalidateCache(roomId);
 
     endPerf('saveChatLog');
 
-    // サーバー側の uuid / time を反映した Chat を返す
-    return {
-      ...chat,
-      uuid: data.uuid,
-      room_id: data.room_id ?? roomId,
-      time: data.time,
-      optimistic: false,
-    };
+    // サーバー側のタイムスタンプを含むデータを返す
+    return data as Chat;
   });
 }
 
 // Fire-and-forget版（レスポンスを待たない最高速版）
 export function saveChatLogFireAndForget(chat: Chat): Promise<void> {
-  const roomId = chat.room_id ?? DEFAULT_ROOM_ID;
+  const sanitized = {
+    // idは除外 - Supabaseでサーバー側のUUID v7を生成
+    room_id: chat.room_id ?? DEFAULT_ROOM_ID,
+    name: chat.name,
+    color: chat.color,
+    message: chat.message,
+    system: chat.system,
+    email: chat.email,
+    ip: chat.ip,
+    ua: chat.ua,
+    metadata: chat.metadata ?? null,
+  };
 
-  // バックグラウンドでの非同期実行。ip / ua は Edge がヘッダから確定する。
+  // バックグラウンドでの非同期実行
   (async () => {
     try {
-      await invokeSaveChat(buildSaveChatPayload(roomId, chat));
+      await supabase.from(TABLE).insert(sanitized);
 
       // 成功時のみキャッシュを無効化
-      invalidateCache(roomId);
+      invalidateCache(chat.room_id ?? DEFAULT_ROOM_ID);
     } catch (error) {
       console.error('Background chat save failed:', error);
     }

--- a/src/features/chat/components/ChatLogList/index.tsx
+++ b/src/features/chat/components/ChatLogList/index.tsx
@@ -1,5 +1,6 @@
 import { Fragment, memo, useMemo } from 'react';
 import type { Chat } from '@features/chat/types';
+import type { RoomId } from '@features/chat/rooms';
 import { useParticipants } from '@features/chat/hooks/useParticipants';
 import { sortChatsByTime } from '@shared/utils/uuid';
 import ParticipantsList from '../ParticipantsList';
@@ -10,16 +11,22 @@ type Props = {
   chatLog: Chat[];
   isLoading?: boolean;
   windowRows: number;
+  showRoomName?: boolean;
+  onRoomClick?: (roomId: RoomId) => void;
+  hideParticipants?: boolean;
 };
 
-function ChatLogList({ chatLog, isLoading = false, windowRows }: Props) {
-  // 表示境界で uuid v7 降順を保証する。useChatLog の reducer / mergeChat は
-  // 常に prepend するため通常時系列だが、out-of-order な realtime INSERT や
-  // 楽観的更新と保存済みログの合流順序に対する防御として明示的に sort する。
+function ChatLogList({
+  chatLog,
+  isLoading = false,
+  windowRows,
+  showRoomName,
+  onRoomClick,
+  hideParticipants,
+}: Props) {
   const chats = useMemo(() => sortChatsByTime(chatLog).slice(0, windowRows), [chatLog, windowRows]);
   const participants = useParticipants(chatLog);
 
-  // 読み込み中の場合は専用のローディング表示を返す
   if (isLoading) {
     return <div className="text-gray-400 mt-8 animate-pulse">チャットログを読み込み中...</div>;
   }
@@ -29,13 +36,12 @@ function ChatLogList({ chatLog, isLoading = false, windowRows }: Props) {
       className="overflow-y-auto rounded-none mt-2 pb-4 font-yui px-[var(--page-gap)]"
       data-testid="chat-log-list"
     >
-      <ParticipantsList participants={participants} />
-      {/* IE風区切り線（上下二重線） */}
+      {!hideParticipants && <ParticipantsList participants={participants} />}
       <Divider />
       {chats.length === 0 && <div className="text-gray-400 py-3">まだ発言はありません。</div>}
       {chats.map((c) => (
         <Fragment key={c.uuid}>
-          <ChatMessage chat={c} />
+          <ChatMessage chat={c} showRoomName={showRoomName} onRoomClick={onRoomClick} />
           <Divider />
         </Fragment>
       ))}

--- a/src/features/chat/components/ChatMessage/index.tsx
+++ b/src/features/chat/components/ChatMessage/index.tsx
@@ -18,7 +18,7 @@ function getTimeDisplay(chat: Chat): string {
 
 function resolveRoomTitle(chat: Chat): string {
   const roomId = chat.room_id;
-  if (!roomId) return String(roomId);
+  if (!roomId) return '不明な部屋';
   try {
     if (!isRoomId(roomId)) return roomId;
     return getRoomMeta(roomId).title;
@@ -36,11 +36,16 @@ function RoomNameLabel({
 }) {
   const title = resolveRoomTitle(chat);
   const roomId = chat.room_id;
+
+  if (!onRoomClick || !roomId) {
+    return <span className="ml-1 text-xs text-gray-500">{title}</span>;
+  }
+
   return (
     <button
       type="button"
       className="ml-1 text-xs text-blue-600 underline cursor-pointer"
-      onClick={() => roomId && onRoomClick?.(roomId)}
+      onClick={() => onRoomClick(roomId)}
       aria-label={`${title}に返信`}
     >
       {title}

--- a/src/features/chat/components/ChatMessage/index.tsx
+++ b/src/features/chat/components/ChatMessage/index.tsx
@@ -3,17 +3,49 @@ import { formatTime } from '@shared/utils/format';
 import { parseMessageSegments } from '@features/chat/utils/urlLinker';
 import { FONT_SIZE_CSS, FONT_COLOR_CSS } from '@features/chat/types';
 import type { Chat } from '@features/chat/types';
+import { isRoomId, getRoomMeta, type RoomId } from '@features/chat/rooms';
 
 type Props = {
   chat: Chat;
+  showRoomName?: boolean;
+  onRoomClick?: (roomId: RoomId) => void;
 };
 
-// 楽観的更新時の時刻表示を生成
 function getTimeDisplay(chat: Chat): string {
-  if (chat.optimistic) {
-    return '送信中...';
-  }
+  if (chat.optimistic) return '送信中...';
   return formatTime(chat.time);
+}
+
+function resolveRoomTitle(chat: Chat): string {
+  const roomId = chat.room_id;
+  if (!roomId) return String(roomId);
+  try {
+    if (!isRoomId(roomId)) return roomId;
+    return getRoomMeta(roomId).title;
+  } catch {
+    return roomId;
+  }
+}
+
+function RoomNameLabel({
+  chat,
+  onRoomClick,
+}: {
+  chat: Chat;
+  onRoomClick?: (roomId: RoomId) => void;
+}) {
+  const title = resolveRoomTitle(chat);
+  const roomId = chat.room_id;
+  return (
+    <button
+      type="button"
+      className="ml-1 text-xs text-blue-600 underline cursor-pointer"
+      onClick={() => roomId && onRoomClick?.(roomId)}
+      aria-label={`${title}に返信`}
+    >
+      {title}
+    </button>
+  );
 }
 
 /** メッセージ本文をセグメント分割してレンダリング（URL自動リンク化） */
@@ -63,7 +95,15 @@ function splitAdminMessage(message: string): { userName: string; rest: string } 
 }
 
 /** 管理人メッセージ専用のレンダリング（レガシー風） */
-function AdminMessage({ chat }: { chat: Chat }) {
+function AdminMessage({
+  chat,
+  showRoomName,
+  onRoomClick,
+}: {
+  chat: Chat;
+  showRoomName?: boolean;
+  onRoomClick?: (roomId: RoomId) => void;
+}) {
   const avatar = chat.metadata?.avatar;
   const userColor = chat.metadata?.userColor ?? '#ff69b4';
   const split = splitAdminMessage(chat.message);
@@ -97,23 +137,28 @@ function AdminMessage({ chat }: { chat: Chat }) {
         </span>
       )}
       <span className={`ml-2 text-xs text-gray-400 ${chat.optimistic ? 'animate-pulse' : ''}`}>
-        ({getTimeDisplay(chat)})
+        ({getTimeDisplay(chat)}
+        {showRoomName && (
+          <>
+            {' / '}
+            <RoomNameLabel chat={chat} onRoomClick={onRoomClick} />
+          </>
+        )}
+        )
       </span>
     </div>
   );
 }
 
-function ChatMessage({ chat }: Props) {
-  // 管理人メッセージは専用レンダリング
+function ChatMessage({ chat, showRoomName, onRoomClick }: Props) {
   if (chat.metadata?.kind === 'admin') {
-    return <AdminMessage chat={chat} />;
+    return <AdminMessage chat={chat} showRoomName={showRoomName} onRoomClick={onRoomClick} />;
   }
 
   const avatar = chat.metadata?.avatar;
 
   return (
     <div className="mb-1">
-      {/* アバター画像（metadata.avatar が存在する場合のみ表示） */}
       {avatar && (
         <img
           src={`${import.meta.env.BASE_URL}avatars/${avatar}.gif`}
@@ -144,7 +189,14 @@ function ChatMessage({ chat }: Props) {
       )}
       <MessageBody message={chat.message} chat={chat} />
       <span className={`ml-2 text-xs text-gray-400 ${chat.optimistic ? 'animate-pulse' : ''}`}>
-        ({getTimeDisplay(chat)})
+        ({getTimeDisplay(chat)}
+        {showRoomName && (
+          <>
+            {' / '}
+            <RoomNameLabel chat={chat} onRoomClick={onRoomClick} />
+          </>
+        )}
+        )
       </span>
     </div>
   );

--- a/src/features/chat/components/ChatRoom/index.tsx
+++ b/src/features/chat/components/ChatRoom/index.tsx
@@ -23,11 +23,13 @@ export type ChatRoomProps = {
   onExit: () => void;
   onSend: (msg: string, metadata?: ChatMetadata) => Promise<void>;
   onReload: () => void;
-  onShowRanking: () => void;
+  onShowRanking?: () => void;
   /** アバター識別子（App.tsx から渡される） */
   avatar?: AvatarId;
   /** 表示用のユーザー名（レガシーの「おなまえ:」表示用） */
   userName?: string;
+  /** Chat-All での返信先部屋名（指定時に「〇〇に返信中」として入力欄付近に表示） */
+  replyTargetTitle?: string;
 };
 
 export default function ChatRoom({
@@ -42,6 +44,7 @@ export default function ChatRoom({
   onShowRanking,
   avatar,
   userName,
+  replyTargetTitle,
 }: ChatRoomProps) {
   const messageId = useId();
   const rowsId = useId();
@@ -101,16 +104,18 @@ export default function ChatRoom({
     <div className="flex flex-col font-yui">
       {/* 1行目: [発言ランキング] [退室] などのリンク群 */}
       <div className="mb-1 flex gap-2 text-green-700 text-sm">
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            onShowRanking();
-          }}
-          className="underline"
-        >
-          [発言ランキング]
-        </a>
+        {onShowRanking && (
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              onShowRanking();
+            }}
+            className="underline"
+          >
+            [発言ランキング]
+          </a>
+        )}
         <a
           href="#"
           onClick={(e) => {
@@ -149,6 +154,11 @@ export default function ChatRoom({
           {userName && (
             <span className="text-sm ml-2">
               おなまえ:<span className="font-bold text-green-700 ml-1">{userName}</span>
+            </span>
+          )}
+          {replyTargetTitle && (
+            <span className="text-sm ml-2 text-blue-700">
+              →<span className="font-bold ml-1">{replyTargetTitle}</span>に返信中
             </span>
           )}
         </div>

--- a/src/features/chat/components/ChatRoom/index.tsx
+++ b/src/features/chat/components/ChatRoom/index.tsx
@@ -30,6 +30,8 @@ export type ChatRoomProps = {
   userName?: string;
   /** Chat-All での返信先部屋名（指定時に「〇〇に返信中」として入力欄付近に表示） */
   replyTargetTitle?: string;
+  /** 「〇〇に返信中」をクリックしたときに呼ばれるコールバック（全部屋まとめにリセット用） */
+  onResetReplyTarget?: () => void;
 };
 
 export default function ChatRoom({
@@ -45,6 +47,7 @@ export default function ChatRoom({
   avatar,
   userName,
   replyTargetTitle,
+  onResetReplyTarget,
 }: ChatRoomProps) {
   const messageId = useId();
   const rowsId = useId();
@@ -157,9 +160,14 @@ export default function ChatRoom({
             </span>
           )}
           {replyTargetTitle && (
-            <span className="text-sm ml-2 text-blue-700">
+            <button
+              type="button"
+              className="text-sm ml-2 text-blue-700 underline cursor-pointer"
+              onClick={onResetReplyTarget}
+              title="クリックで全部屋まとめに戻す"
+            >
               →<span className="font-bold ml-1">{replyTargetTitle}</span>に返信中
-            </span>
+            </button>
           )}
         </div>
         {/* 3行目: 発言入力欄（独立行） */}

--- a/src/features/chat/hooks/useAllRoomsChatHandlers.ts
+++ b/src/features/chat/hooks/useAllRoomsChatHandlers.ts
@@ -1,0 +1,218 @@
+import { useCallback, useTransition } from 'react';
+import {
+  saveChatLogOptimistic,
+  clearChatLogsByName,
+  createOptimisticChat,
+} from '@features/chat/api/chatApi';
+import { validateName } from '@features/chat/utils/validation';
+import { trackEvent } from '@shared/utils/analytics';
+import { isFortuneCommand, generateFortune } from '@features/chat/utils/fortuneBot';
+import { isBlankMessage, isClearTarget } from '@features/chat/utils/chatAllSend';
+import type { Chat, ChatMetadata, AvatarId } from '@features/chat/types';
+import type { Dispatch, SetStateAction } from 'react';
+import type { RoomId } from '@features/chat/rooms';
+
+export function useAllRoomsChatHandlers({
+  replyTarget,
+  name,
+  color,
+  email,
+  avatar,
+  fontStyle,
+  setEntered,
+  setChatLog,
+  setName,
+  setMessage,
+  addOptimistic,
+  mergeChat,
+}: {
+  replyTarget: RoomId;
+  name: string;
+  color: string;
+  email: string;
+  avatar?: AvatarId;
+  fontStyle?: ChatMetadata['fontStyle'];
+  setEntered: Dispatch<SetStateAction<boolean>>;
+  setChatLog: Dispatch<SetStateAction<Chat[]>>;
+  setName: Dispatch<SetStateAction<string>>;
+  setMessage: Dispatch<SetStateAction<string>>;
+  addOptimistic: (chat: Chat) => void;
+  mergeChat: (chat: Chat) => void;
+}) {
+  const [, startTransition] = useTransition();
+
+  const buildAdminOptimistic = useCallback(
+    (message: string, userColor: string) =>
+      createOptimisticChat({
+        room_id: 'all',
+        name: '管理人',
+        color: '#ffffff',
+        message,
+        client_time: Date.now(),
+        system: true,
+        ip: '',
+        ua: '',
+        metadata: {
+          version: 1,
+          avatar: 'hoshi1',
+          kind: 'admin',
+          userColor,
+          fontStyle: { bold: true },
+        },
+      }),
+    []
+  );
+
+  const handleEnter = useCallback(
+    async ({
+      name: entryName,
+      color: entryColor,
+      silent = false,
+    }: {
+      name: string;
+      color: string;
+      email?: string;
+      silent?: boolean;
+    }) => {
+      const err = validateName(entryName);
+      if (err) throw new Error(err);
+      setEntered(true);
+
+      if (silent) {
+        trackEvent('chat_enter', { room_id: 'all', room_title: '全部屋まとめ' });
+        return;
+      }
+
+      const optimistic = buildAdminOptimistic(
+        `${entryName} さん、Welcome to お気楽チャット☆`,
+        entryColor
+      );
+      startTransition(() => addOptimistic(optimistic));
+
+      const savedChat = await saveChatLogOptimistic('all', optimistic);
+      startTransition(() => mergeChat(savedChat));
+      trackEvent('chat_enter', { room_id: 'all', room_title: '全部屋まとめ' });
+    },
+    [buildAdminOptimistic, setEntered, addOptimistic, mergeChat]
+  );
+
+  const handleExit = useCallback(async () => {
+    trackEvent('chat_exit', { room_id: 'all', room_title: '全部屋まとめ' });
+
+    const optimistic = buildAdminOptimistic(`${name}さん、またきておくれやすぅ。`, color);
+    startTransition(() => addOptimistic(optimistic));
+
+    setEntered(false);
+    setName('');
+    setMessage('');
+
+    const savedChat = await saveChatLogOptimistic('all', optimistic);
+    startTransition(() => mergeChat(savedChat));
+  }, [
+    buildAdminOptimistic,
+    name,
+    color,
+    setEntered,
+    setName,
+    setMessage,
+    addOptimistic,
+    mergeChat,
+  ]);
+
+  const handleSend = useCallback(
+    async (msg: string, metadata?: ChatMetadata) => {
+      if (isBlankMessage(msg)) return;
+
+      const trimmed = msg.trim();
+
+      if (trimmed === 'cut') {
+        trackEvent('command_used', { room_id: replyTarget, command: 'cut' });
+        setMessage('');
+        return;
+      }
+
+      if (trimmed === 'clear') {
+        const targets = await (async () => {
+          return new Promise<Chat[]>((resolve) => {
+            setChatLog((prev) => {
+              const t = prev.filter((c) => isClearTarget(c, replyTarget, name));
+              resolve(t);
+              return prev;
+            });
+          });
+        })();
+
+        if (targets.length === 0) {
+          setMessage('');
+          throw new Error('削除対象の発言がありません');
+        }
+
+        await clearChatLogsByName(replyTarget, name);
+        trackEvent('command_used', { room_id: replyTarget, command: 'clear' });
+        setChatLog((prev) => prev.filter((c) => !isClearTarget(c, replyTarget, name)));
+        setMessage('');
+        return;
+      }
+
+      const metaBase: ChatMetadata = { version: 1 };
+      if (fontStyle) metaBase.fontStyle = fontStyle;
+      if (avatar && avatar !== 'none') metaBase.avatar = avatar as Exclude<AvatarId, 'none'>;
+
+      const resolvedMetadata: ChatMetadata = metadata ? { ...metaBase, ...metadata } : metaBase;
+
+      const optimistic = createOptimisticChat({
+        room_id: replyTarget,
+        name,
+        color,
+        message: msg,
+        client_time: Date.now(),
+        email,
+        ip: '',
+        ua: '',
+        metadata: resolvedMetadata,
+      });
+
+      startTransition(() => addOptimistic(optimistic));
+      setMessage('');
+
+      const savedChat = await saveChatLogOptimistic(replyTarget, optimistic);
+      startTransition(() => mergeChat(savedChat));
+
+      if (isFortuneCommand(msg)) {
+        try {
+          const fortune = generateFortune(name);
+          const fortuneOptimistic = createOptimisticChat({
+            room_id: replyTarget,
+            name: fortune.senderName,
+            color: fortune.color,
+            message: fortune.message,
+            client_time: Date.now(),
+            system: true,
+            ip: '',
+            ua: '',
+            metadata: { version: 1, kind: 'fortune', avatar: 'miko1', fontStyle: { bold: true } },
+          });
+          startTransition(() => addOptimistic(fortuneOptimistic));
+          const savedFortune = await saveChatLogOptimistic(replyTarget, fortuneOptimistic);
+          startTransition(() => mergeChat(savedFortune));
+        } catch {
+          // 巫女メッセージの保存失敗はサイレントに無視
+        }
+      }
+    },
+    [
+      replyTarget,
+      name,
+      color,
+      email,
+      avatar,
+      fontStyle,
+      setMessage,
+      setChatLog,
+      addOptimistic,
+      mergeChat,
+    ]
+  );
+
+  return { handleEnter, handleExit, handleSend };
+}

--- a/src/features/chat/hooks/useAllRoomsChatLog.ts
+++ b/src/features/chat/hooks/useAllRoomsChatLog.ts
@@ -14,12 +14,16 @@ export function useAllRoomsChatLog(): {
   setChatLog: Dispatch<SetStateAction<Chat[]>>;
   addOptimistic: (chat: Chat) => void;
   mergeChat: (chat: Chat) => void;
+  reload: () => void;
 } {
   const [baseLog, setBaseLog] = useState<Chat[]>([]);
   // 初期値 true: マウント直後は読み込み中
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [subscribeError, setSubscribeError] = useState(false);
+  // reload ごとにインクリメントして effect を再実行させる
+  const [reloadKey, setReloadKey] = useState(0);
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
   // effect が再実行されたとき同期 setState を避けるため ref で管理する
   const effectRunRef = useRef(0);
 
@@ -50,7 +54,8 @@ export function useAllRoomsChatLog(): {
 
     loadAllRoomsChatLogs(200)
       .then((logs) => {
-        if (!ignore) setBaseLog(logs);
+        // realtime で先着した新着を丸ごと上書きしないよう merge する
+        if (!ignore) setBaseLog((prev) => mergeAggregatedLog(logs, prev));
       })
       .catch(() => {
         if (!ignore) setLoadError(true);
@@ -61,11 +66,18 @@ export function useAllRoomsChatLog(): {
 
     let sub: ReturnType<typeof subscribeAllRoomsChatLogs> | null = null;
     try {
-      sub = subscribeAllRoomsChatLogs((chat) => {
-        if (!ignore) mergeChat(chat);
-      });
+      sub = subscribeAllRoomsChatLogs(
+        (chat) => {
+          if (!ignore) mergeChat(chat);
+        },
+        () => {
+          // CHANNEL_ERROR / TIMED_OUT / CLOSED: 同期 setState を避けるため非同期で更新
+          void Promise.resolve().then(() => {
+            if (!ignore) setSubscribeError(true);
+          });
+        }
+      );
     } catch {
-      // 同期 setState を避けるため非同期で更新
       void Promise.resolve().then(() => {
         if (!ignore) setSubscribeError(true);
       });
@@ -75,7 +87,7 @@ export function useAllRoomsChatLog(): {
       ignore = true;
       sub?.unsubscribe();
     };
-  }, [mergeChat]);
+  }, [mergeChat, reloadKey]);
 
   return {
     chatLog,
@@ -86,5 +98,6 @@ export function useAllRoomsChatLog(): {
     setChatLog: setBaseLog,
     addOptimistic,
     mergeChat,
+    reload,
   };
 }

--- a/src/features/chat/hooks/useAllRoomsChatLog.ts
+++ b/src/features/chat/hooks/useAllRoomsChatLog.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState, useOptimistic, startTransition } from 'react';
+import { loadAllRoomsChatLogs, subscribeAllRoomsChatLogs } from '@features/chat/api/chatAllApi';
+import { mergeAggregatedLog } from '@features/chat/utils/aggregatedLog';
+import { reduceOptimisticChat } from './useChatLog';
+import type { Chat } from '@features/chat/types';
+import type { Dispatch, SetStateAction } from 'react';
+
+export function useAllRoomsChatLog(): {
+  chatLog: Chat[];
+  isLoading: boolean;
+  loadError: boolean;
+  subscribeError: boolean;
+  isEmpty: boolean;
+  setChatLog: Dispatch<SetStateAction<Chat[]>>;
+  addOptimistic: (chat: Chat) => void;
+  mergeChat: (chat: Chat) => void;
+} {
+  const [baseLog, setBaseLog] = useState<Chat[]>([]);
+  // 初期値 true: マウント直後は読み込み中
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [subscribeError, setSubscribeError] = useState(false);
+  // effect が再実行されたとき同期 setState を避けるため ref で管理する
+  const effectRunRef = useRef(0);
+
+  const mergeChat = useCallback((chat: Chat) => {
+    setBaseLog((prev) => mergeAggregatedLog(prev, chat));
+  }, []);
+
+  const [chatLog, addOptimisticInternal] = useOptimistic(baseLog, reduceOptimisticChat);
+
+  const addOptimistic = useCallback(
+    (chat: Chat) => {
+      startTransition(() => {
+        addOptimisticInternal(chat);
+      });
+    },
+    [addOptimisticInternal]
+  );
+
+  useEffect(() => {
+    let ignore = false;
+    const run = ++effectRunRef.current;
+
+    // 再実行時のみリセット（初回は useState の初期値のまま）
+    if (run > 1) {
+      setIsLoading(true);
+      setLoadError(false);
+    }
+
+    loadAllRoomsChatLogs(200)
+      .then((logs) => {
+        if (!ignore) setBaseLog(logs);
+      })
+      .catch(() => {
+        if (!ignore) setLoadError(true);
+      })
+      .finally(() => {
+        if (!ignore) setIsLoading(false);
+      });
+
+    let sub: ReturnType<typeof subscribeAllRoomsChatLogs> | null = null;
+    try {
+      sub = subscribeAllRoomsChatLogs((chat) => {
+        if (!ignore) mergeChat(chat);
+      });
+    } catch {
+      // 同期 setState を避けるため非同期で更新
+      void Promise.resolve().then(() => {
+        if (!ignore) setSubscribeError(true);
+      });
+    }
+
+    return () => {
+      ignore = true;
+      sub?.unsubscribe();
+    };
+  }, [mergeChat]);
+
+  return {
+    chatLog,
+    isLoading,
+    loadError,
+    subscribeError,
+    isEmpty: !isLoading && !loadError && baseLog.length === 0,
+    setChatLog: setBaseLog,
+    addOptimistic,
+    mergeChat,
+  };
+}

--- a/src/features/chat/hooks/useReplyTarget.ts
+++ b/src/features/chat/hooks/useReplyTarget.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+import type { RoomId } from '@features/chat/rooms';
+
+export function useReplyTarget() {
+  const [replyTarget, setReplyTarget] = useState<RoomId>('all');
+  return { replyTarget, setReplyTarget };
+}

--- a/src/features/chat/rooms.ts
+++ b/src/features/chat/rooms.ts
@@ -94,6 +94,8 @@ export const CHAT_ROOM_IDS = [
   'dgrayman',
   'haruhi',
   'railgun',
+  // Chat-All 専用
+  'all',
 ] as const;
 
 export type RoomId = (typeof CHAT_ROOM_IDS)[number];
@@ -210,6 +212,7 @@ const ROOM_TITLES: Record<RoomId, string> = {
   dgrayman: 'Dグレチャット',
   haruhi: '涼宮ハルヒの憂鬱チャット',
   railgun: 'とある科学のレールガンチャット',
+  all: '全部屋まとめ',
 };
 
 function buildRoomMeta(): Record<RoomId, RoomMeta> {
@@ -235,6 +238,14 @@ export function isEnabledRoomId(value: string): value is RoomId {
   return isRoomId(value) && CHAT_ROOMS[value].enabled;
 }
 
+export function getListableRoomIds(): ReadonlyArray<RoomId> {
+  return CHAT_ROOM_IDS.filter((id) => id !== 'all') as ReadonlyArray<RoomId>;
+}
+
 export function getRoomMeta(roomId: RoomId): RoomMeta {
-  return CHAT_ROOMS[roomId];
+  const meta = CHAT_ROOMS[roomId];
+  if (!meta) {
+    throw new Error(`Unknown room_id: ${roomId}`);
+  }
+  return meta;
 }

--- a/src/features/chat/utils/aggregatedLog.ts
+++ b/src/features/chat/utils/aggregatedLog.ts
@@ -1,0 +1,23 @@
+import type { Chat } from '@features/chat/types';
+import { sortChatsByTime } from '@shared/utils/uuid';
+
+const MAX_AGGREGATED_LOG = 2000;
+
+/**
+ * Aggregated_Log のマージ純粋関数。
+ * - uuid による重複排除（同一 uuid は置換）
+ * - uuid v7 降順の整列
+ * - 2000 件キャップ（超過時は最古から破棄）
+ * - Source_Room_Id（room_id）を保持
+ */
+export function mergeAggregatedLog(state: Chat[], incoming: Chat | Chat[]): Chat[] {
+  const incomingArray = Array.isArray(incoming) ? incoming : [incoming];
+  if (incomingArray.length === 0) return state;
+
+  const map = new Map<string, Chat>();
+  for (const c of state) map.set(c.uuid, c);
+  for (const c of incomingArray) map.set(c.uuid, c);
+
+  const merged = sortChatsByTime(Array.from(map.values()));
+  return merged.slice(0, MAX_AGGREGATED_LOG);
+}

--- a/src/features/chat/utils/chatAllSend.ts
+++ b/src/features/chat/utils/chatAllSend.ts
@@ -1,0 +1,61 @@
+import type { Chat, ChatMetadata, AvatarId } from '@features/chat/types';
+import type { RoomId } from '@features/chat/rooms';
+
+export type AllRoomsIdentity = {
+  name: string;
+  color: string;
+  email?: string;
+  avatar?: AvatarId;
+  fontStyle?: ChatMetadata['fontStyle'];
+};
+
+/** 空・空白文字のみの発言を判定する */
+export function isBlankMessage(msg: string): boolean {
+  return msg.trim().length === 0;
+}
+
+/**
+ * Chat-All 送信ペイロードを構築する純粋関数。
+ * 保存先 room_id を replyTarget に、kind を通常発言に設定する。
+ */
+export function buildAllRoomsSendPayload({
+  replyTarget,
+  identity,
+  message,
+  metadata,
+}: {
+  replyTarget: RoomId;
+  identity: AllRoomsIdentity;
+  message: string;
+  metadata?: ChatMetadata;
+}): { roomId: RoomId; chatData: Omit<Chat, 'uuid' | 'time' | 'optimistic'> } {
+  const base: ChatMetadata = { version: 1 };
+  if (identity.fontStyle) base.fontStyle = identity.fontStyle;
+  if (identity.avatar && identity.avatar !== 'none') {
+    base.avatar = identity.avatar as Exclude<AvatarId, 'none'>;
+  }
+
+  const resolvedMetadata: ChatMetadata = metadata
+    ? { ...base, ...metadata, kind: undefined }
+    : base;
+
+  return {
+    roomId: replyTarget,
+    chatData: {
+      room_id: replyTarget,
+      name: identity.name,
+      color: identity.color,
+      message,
+      client_time: Date.now(),
+      email: identity.email,
+      ip: '',
+      ua: '',
+      metadata: resolvedMetadata,
+    },
+  };
+}
+
+/** clear コマンドの対象判定: 現在の返信先部屋かつ自分の発言のみ */
+export function isClearTarget(chat: Chat, replyTarget: RoomId, myName: string): boolean {
+  return chat.room_id === replyTarget && chat.name === myName;
+}

--- a/src/features/chat/utils/chatAllSend.ts
+++ b/src/features/chat/utils/chatAllSend.ts
@@ -35,9 +35,15 @@ export function buildAllRoomsSendPayload({
     base.avatar = identity.avatar as Exclude<AvatarId, 'none'>;
   }
 
-  const resolvedMetadata: ChatMetadata = metadata
-    ? { ...base, ...metadata, kind: undefined }
-    : base;
+  let resolvedMetadata: ChatMetadata;
+  if (metadata) {
+    const rest: Omit<ChatMetadata, 'kind'> = Object.fromEntries(
+      Object.entries(metadata).filter(([k]) => k !== 'kind')
+    ) as Omit<ChatMetadata, 'kind'>;
+    resolvedMetadata = { ...base, ...rest };
+  } else {
+    resolvedMetadata = base;
+  }
 
   return {
     roomId: replyTarget,

--- a/src/features/top/api/roomCountsApi.ts
+++ b/src/features/top/api/roomCountsApi.ts
@@ -77,12 +77,13 @@ export async function fetchRoomParticipantCounts(
  * 管理人メッセージ (metadata.kind === 'admin') および system フラグ付き行はスキップする。
  */
 export function aggregateCountsFromRows(rows: readonly ChatRow[]): RoomCountMap {
+  const listableRoomIdSet = new Set<string>(getListableRoomIds());
   const participantsByRoom = new Map<RoomId, Set<string>>();
 
   for (const row of rows) {
     const roomId = row.room_id as RoomId | null;
     if (!roomId) continue;
-    if (!(getListableRoomIds() as readonly string[]).includes(roomId)) continue;
+    if (!listableRoomIdSet.has(roomId)) continue;
     if (row.system) continue;
     if (row.metadata?.kind === 'admin') continue;
     if (!row.name) continue;

--- a/src/features/top/api/roomCountsApi.ts
+++ b/src/features/top/api/roomCountsApi.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@shared/supabaseClient';
-import { CHAT_ROOM_IDS, type RoomId } from '@features/chat/rooms';
+import { getListableRoomIds, type RoomId } from '@features/chat/rooms';
 import type { ChatMetadata } from '@features/chat/types';
 
 /** 直近の参加者カウントを返す辞書型 (未取得のルームはキーに存在しない) */
@@ -49,7 +49,7 @@ export async function fetchRoomParticipantCounts(
       .from('chats')
       .select('room_id, name, message, system, metadata, time')
       .gte('time', since)
-      .in('room_id', CHAT_ROOM_IDS as unknown as string[])
+      .in('room_id', getListableRoomIds() as unknown as string[])
       .eq('deleted', false)
       .order('time', { ascending: true })
       .limit(5000);
@@ -82,7 +82,7 @@ export function aggregateCountsFromRows(rows: readonly ChatRow[]): RoomCountMap 
   for (const row of rows) {
     const roomId = row.room_id as RoomId | null;
     if (!roomId) continue;
-    if (!CHAT_ROOM_IDS.includes(roomId)) continue;
+    if (!(getListableRoomIds() as readonly string[]).includes(roomId)) continue;
     if (row.system) continue;
     if (row.metadata?.kind === 'admin') continue;
     if (!row.name) continue;

--- a/src/features/top/data.ts
+++ b/src/features/top/data.ts
@@ -94,6 +94,7 @@ export const tabNav = [
   { label: '大学生チャット', href: buildChatRoomPath('daigaku') },
   { label: '超初心者チャット', href: buildChatRoomPath('superbeginner') },
   { label: 'なりきりチャット', href: '#pickup-narikiri' },
+  { label: '全部屋チャット', href: buildChatRoomPath('all') },
 ];
 
 /**

--- a/src/routes/AllRoomsRoute.tsx
+++ b/src/routes/AllRoomsRoute.tsx
@@ -120,6 +120,7 @@ export default function AllRoomsRoute() {
                 avatar={avatar}
                 userName={name}
                 replyTargetTitle={replyTargetTitle}
+                onResetReplyTarget={() => setReplyTarget('all')}
               />
             ) : (
               <EntryForm

--- a/src/routes/AllRoomsRoute.tsx
+++ b/src/routes/AllRoomsRoute.tsx
@@ -36,6 +36,7 @@ export default function AllRoomsRoute() {
     setChatLog,
     addOptimistic,
     mergeChat,
+    reload,
   } = useAllRoomsChatLog();
   const { replyTarget, setReplyTarget } = useReplyTarget();
   const { settings } = useSettings();
@@ -115,7 +116,7 @@ export default function AllRoomsRoute() {
                 setWindowRows={setWindowRows}
                 onExit={handleExit}
                 onSend={wrappedHandleSend}
-                onReload={() => {}}
+                onReload={reload}
                 avatar={avatar}
                 userName={name}
                 replyTargetTitle={replyTargetTitle}

--- a/src/routes/AllRoomsRoute.tsx
+++ b/src/routes/AllRoomsRoute.tsx
@@ -1,0 +1,165 @@
+import { useState, lazy, Suspense } from 'react';
+import { useAllRoomsChatLog } from '@features/chat/hooks/useAllRoomsChatLog';
+import { useAllRoomsChatHandlers } from '@features/chat/hooks/useAllRoomsChatHandlers';
+import { useReplyTarget } from '@features/chat/hooks/useReplyTarget';
+import { useSettings } from '@features/chat/hooks/useSettings';
+import { useSEO, usePageView } from '@shared/hooks/useSEO';
+import { getRoomMeta } from '@features/chat/rooms';
+import type { RoomId } from '@features/chat/rooms';
+import type { AvatarId } from '@features/chat/types';
+import ChatRoom from '@features/chat/components/ChatRoom';
+import EntryForm from '@features/chat/components/EntryForm';
+import RetroSplitter from '@features/chat/components/RetroSplitter';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
+import { buildAbsoluteUrl } from '@shared/utils/seo';
+import { buildChatRoomPath } from '@features/chat/routing';
+
+const ChatLogList = lazy(() => import('@features/chat/components/ChatLogList'));
+
+const ROOM_META = getRoomMeta('all');
+
+export default function AllRoomsRoute() {
+  useSEO({
+    title: `${ROOM_META.title} | ゆいちゃっとTS`,
+    description: '全部屋の発言を 1 画面で横断表示する集約チャットビューです。',
+    keywords: ['ゆいちゃっとTS', 'お気楽チャット', '全部屋まとめ'],
+    canonical: buildAbsoluteUrl(buildChatRoomPath('all')),
+  });
+  usePageView(`${ROOM_META.title} - ゆいちゃっとTS`);
+
+  const {
+    chatLog,
+    isLoading,
+    loadError,
+    subscribeError,
+    isEmpty,
+    setChatLog,
+    addOptimistic,
+    mergeChat,
+  } = useAllRoomsChatLog();
+  const { replyTarget, setReplyTarget } = useReplyTarget();
+  const { settings } = useSettings();
+
+  const [entered, setEntered] = useState(false);
+  const [name, setName] = useState(() => settings.name ?? '');
+  const [color, setColor] = useState(() => settings.color || '#ff69b4');
+  const [email, setEmail] = useState(() => settings.email ?? '');
+  const [avatar, setAvatar] = useState<AvatarId>(() => settings.avatar ?? 'none');
+  const [message, setMessage] = useState('');
+  const [windowRows, setWindowRows] = useState(30);
+  const [sendError, setSendError] = useState('');
+
+  const { handleEnter, handleExit, handleSend } = useAllRoomsChatHandlers({
+    replyTarget,
+    name,
+    color,
+    email,
+    avatar,
+    setEntered,
+    setChatLog,
+    setName,
+    setMessage,
+    addOptimistic,
+    mergeChat,
+  });
+
+  const replyTargetTitle = getRoomMeta(replyTarget).title;
+
+  const handleRoomClick = (roomId: RoomId) => {
+    setReplyTarget(roomId);
+  };
+
+  const wrappedHandleSend = async (msg: string, ...args: Parameters<typeof handleSend>[1][]) => {
+    setSendError('');
+    try {
+      await handleSend(msg, args[0]);
+    } catch (err) {
+      setSendError((err as Error)?.message ?? '送信エラー');
+    }
+  };
+
+  return (
+    <ErrorBoundary
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center bg-yui-green">
+          <div className="text-red-600 px-4 py-2">
+            全部屋まとめの読み込みに失敗しました。ページを再読み込みしてください。
+          </div>
+        </div>
+      }
+    >
+      <main className="flex min-h-dvh h-dvh flex-col overflow-hidden bg-yui-green" role="main">
+        <header className="sr-only">
+          <h1>{ROOM_META.title}</h1>
+          <p>{ROOM_META.description}</p>
+        </header>
+        {(loadError || subscribeError) && (
+          <div className="text-red-500 text-xs px-[var(--page-gap)] py-1">
+            {loadError && 'チャットログの読み込みに失敗しました。'}
+            {subscribeError && 'リアルタイム購読の確立に失敗しました。'}
+          </div>
+        )}
+        {sendError && (
+          <div className="text-red-500 text-xs px-[var(--page-gap)] py-1">{sendError}</div>
+        )}
+        <RetroSplitter
+          minTop={100}
+          minBottom={100}
+          top={
+            entered ? (
+              <ChatRoom
+                message={message}
+                setMessage={setMessage}
+                chatLog={chatLog}
+                windowRows={windowRows}
+                setWindowRows={setWindowRows}
+                onExit={handleExit}
+                onSend={wrappedHandleSend}
+                onReload={() => {}}
+                avatar={avatar}
+                userName={name}
+                replyTargetTitle={replyTargetTitle}
+              />
+            ) : (
+              <EntryForm
+                roomTitle={ROOM_META.title}
+                name={name}
+                setName={setName}
+                color={color}
+                setColor={setColor}
+                email={email}
+                setEmail={setEmail}
+                onEnter={({ name: n, color: c, email: e, silent, avatar: a }) => {
+                  setAvatar(a);
+                  return handleEnter({ name: n, color: c, email: e, silent });
+                }}
+              />
+            )
+          }
+          bottom={
+            <Suspense
+              fallback={
+                <div className="mt-8 animate-pulse text-gray-400">チャットログを読み込み中...</div>
+              }
+            >
+              {isEmpty ? (
+                <div className="text-gray-400 px-[var(--page-gap)] py-3 mt-2 font-yui">
+                  まだ発言はありません。
+                </div>
+              ) : (
+                <ChatLogList
+                  chatLog={chatLog}
+                  isLoading={isLoading}
+                  windowRows={windowRows}
+                  showRoomName
+                  onRoomClick={handleRoomClick}
+                  hideParticipants
+                />
+              )}
+            </Suspense>
+          }
+        />
+      </main>
+    </ErrorBoundary>
+  );
+}

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+type Props = {
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (import.meta.env.DEV) {
+      console.error('[ErrorBoundary] caught:', error, info);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="text-red-500 px-4 py-2 text-sm">
+            エラーが発生しました。ページを再読み込みしてください。
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

- `room_id='all'` でルーム横断の発言タイムラインを表示する `AllRoomsRoute` / `useAllRoomsChatLog` / `useAllRoomsChatHandlers` を実装
- `ChatMessage` に `showRoomName` / `onRoomClick` prop を追加し、全部屋ビューで部屋名をクリックすると返信先ルームを切替可能に
- `rooms.ts` に `'all'` を追加し、`getListableRoomIds()` でサイトマップ・参加者数集計から除外
- 全部屋ビューは `deleted=true` を含めて全メッセージを表示（モデレーション目的）
- `save-chat` Edge Function 経由の INSERT に統一し `ip`/`ua` をサーバー観測値として記録（`clientInfo.ts` 依存を除去）
- `ErrorBoundary` コンポーネントを追加し、Cross-Room-Mode の例外を隔離

## Test plan

- [ ] `/chat/all` にアクセスして全部屋タイムラインが表示されることを確認
- [ ] 部屋名ラベルをクリックして返信先が切り替わることを確認
- [ ] 発言フォームから送信し、該当ルームに保存されることを確認
- [ ] 既存の個別ルーム (`/chat/superbeginner` 等) が引き続き正常に動作することを確認
- [ ] トップページのナビゲーションに「全部屋チャット」リンクが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)