### PR TITLE
feat: superbeginner ルームに LLM チャットボット (bot-respond) を追加

### DIFF
--- a/docs/bot-respond-deploy.md
+++ b/docs/bot-respond-deploy.md
@@ -29,9 +29,7 @@ supabase migration list                                    # local/remote 整合
 ```bash
 # 必須
 supabase secrets set OPENAI_API_KEY=sk-...
-
-# 任意(Webhook 軽量認証を使う場合)
-supabase secrets set BOT_WEBHOOK_SECRET=<ランダムな文字列>
+supabase secrets set BOT_WEBHOOK_SECRET=<ランダムな文字列>  # secret 未設定だと関数が全リクエストを拒否する
 
 # 必要に応じてカスタマイズ
 supabase secrets set BOT_MODEL=gpt-4o-mini
@@ -70,7 +68,7 @@ Supabase ダッシュボード → **Database → Webhooks → Create a new hook
 | Type | Supabase Edge Functions |
 | Edge Function | `bot-respond` |
 | HTTP Headers | `Authorization: Bearer <anon key>` (必須) |
-| HTTP Headers | `x-bot-webhook-secret: <BOT_WEBHOOK_SECRET>` (任意・設定した場合) |
+| HTTP Headers | `x-bot-webhook-secret: <BOT_WEBHOOK_SECRET>` (必須) |
 
 > **重要**: Webhook は**全ルームの全 INSERT** で発火する。`bot-respond` は `record.room_id !== 'superbeginner'` を DB アクセス前に弾くため、他ルームのコスト影響は最小限。
 

--- a/docs/bot-respond-deploy.md
+++ b/docs/bot-respond-deploy.md
@@ -1,0 +1,107 @@
+# bot-respond デプロイ・運用チェックリスト
+
+> **これらはすべて手動(ops)操作です。** コードの変更ではなく、Supabase ダッシュボード / CLI での設定作業です。
+
+---
+
+## 前提
+
+- `supabase link --project-ref <ref>` でローカル CLI がプロジェクトに接続済みであること。
+- `OPENAI_API_KEY` が取得済みであること。
+- 既存マイグレーション(`baseline_schema` / `lock_insert_to_service_role`)は本番 DB 適用済み。
+
+---
+
+## 1. マイグレーション履歴の整合
+
+Bot 機能は**新規テーブル・カラムなし**。ただし、CLI が未適用と誤認識する場合は以下で修正する。
+
+```bash
+supabase migration repair --status applied 20250618000000  # baseline_schema
+supabase migration repair --status applied 20250619000000  # lock_insert_to_service_role
+supabase migration list                                    # local/remote 整合確認
+```
+
+---
+
+## 2. シークレットの設定
+
+```bash
+# 必須
+supabase secrets set OPENAI_API_KEY=sk-...
+
+# 任意(Webhook 軽量認証を使う場合)
+supabase secrets set BOT_WEBHOOK_SECRET=<ランダムな文字列>
+
+# 必要に応じてカスタマイズ
+supabase secrets set BOT_MODEL=gpt-4o-mini
+supabase secrets set BOT_SYSTEM_PROMPT="あなたはゆいちゃっとのアシスタントです。"
+supabase secrets set BOT_NAME="ゆいボット"
+supabase secrets set BOT_GREETINGS="こんにちは\nよろしくね"
+supabase secrets set BOT_COOLDOWN_MIN_MS=8000
+supabase secrets set BOT_COOLDOWN_MAX_MS=15000
+supabase secrets set BOT_RESPONSE_DELAY_MIN_MS=2000
+supabase secrets set BOT_RESPONSE_DELAY_MAX_MS=6000
+supabase secrets set BOT_HISTORY_MESSAGE_CAP=20
+supabase secrets set BOT_TARGET_ROOM=superbeginner
+```
+
+`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` は Edge Function 実行環境に自動注入されるため不要。
+
+---
+
+## 3. Edge Function のデプロイ
+
+```bash
+supabase functions deploy bot-respond
+```
+
+---
+
+## 4. Database Webhook の作成
+
+Supabase ダッシュボード → **Database → Webhooks → Create a new hook** で以下を設定する。
+
+| 設定項目 | 値 |
+|---------|-----|
+| Name | `chats-insert-bot-respond` |
+| Table | `public.chats` |
+| Events | `INSERT` のみ |
+| Type | Supabase Edge Functions |
+| Edge Function | `bot-respond` |
+| HTTP Headers | `Authorization: Bearer <anon key>` (必須) |
+| HTTP Headers | `x-bot-webhook-secret: <BOT_WEBHOOK_SECRET>` (任意・設定した場合) |
+
+> **重要**: Webhook は**全ルームの全 INSERT** で発火する。`bot-respond` は `record.room_id !== 'superbeginner'` を DB アクセス前に弾くため、他ルームのコスト影響は最小限。
+
+---
+
+## 5. OpenAI の予算上限設定(推奨)
+
+OpenAI ダッシュボード → **Settings → Limits** でハード予算上限を設定することを強く推奨する。
+
+- 月次ハード上限: 運用コストの上限として設定(例: $10/月)
+- `bot-respond` は 429 エラーを握りつぶして `200` を返すため、上限超過時は自動的に Bot が沈黙する(チャット自体は継続)。
+
+---
+
+## 6. ローカル検証
+
+```bash
+supabase start
+supabase functions serve bot-respond
+
+# Webhook ペイロード相当の JSON を POST して挙動確認
+curl -X POST http://localhost:54321/functions/v1/bot-respond \
+  -H "Content-Type: application/json" \
+  -H "x-bot-webhook-secret: <secret>" \
+  -d '{"type":"INSERT","table":"chats","record":{"uuid":"test","room_id":"superbeginner","name":"alice","color":"#fff","message":"こんにちは","time":1700000000000,"metadata":{"version":1,"kind":"normal"}}}'
+```
+
+---
+
+## 7. ESLint の分離確認
+
+`eslint.config.js` は `supabase/functions/**` を app lint から除外済み。`bot-respond` と `_shared` もこの除外に含まれるため追加設定不要。
+
+Deno 側の型チェックは `deno check supabase/functions/bot-respond/index.ts` で別系統実施（任意）。

--- a/docs/save-chat-edge-function.md
+++ b/docs/save-chat-edge-function.md
@@ -71,32 +71,32 @@ useChatHandlers
 
 ### バックエンド（新規）
 
-| ファイル | 内容 |
-|---|---|
-| `supabase/functions/save-chat/index.ts` | Edge Function 本体（Deno）。CORS・最小バリデーション・`ip`/`ua` 確定・`service_role` INSERT |
-| `supabase/functions/save-chat/deno.json` | Deno 用 import map（`@supabase/supabase-js`） |
-| `supabase/config.toml` | `[functions.save-chat] verify_jwt = false`（匿名チャットのため） |
-| `supabase/migrations/20250619000000_lock_insert_to_service_role.sql` | `chats` の INSERT を `service_role` のみに封鎖 |
+| ファイル                                                             | 内容                                                                                        |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `supabase/functions/save-chat/index.ts`                              | Edge Function 本体（Deno）。CORS・最小バリデーション・`ip`/`ua` 確定・`service_role` INSERT |
+| `supabase/functions/save-chat/deno.json`                             | Deno 用 import map（`@supabase/supabase-js`）                                               |
+| `supabase/config.toml`                                               | `[functions.save-chat] verify_jwt = false`（匿名チャットのため）                            |
+| `supabase/migrations/20250619000000_lock_insert_to_service_role.sql` | `chats` の INSERT を `service_role` のみに封鎖                                              |
 
 ### クライアント
 
-| ファイル | 変更 |
-|---|---|
-| `src/features/chat/api/chatApi.ts` | `saveChatLogOptimistic` / `saveChatLog` / `saveChatLogFireAndForget` を `functions.invoke('save-chat')` 経由に。`ip`/`ua` を送らない |
-| `src/features/chat/hooks/useChatHandlers.ts` | `getClientIP` / `getUserAgent` 取得（入室・退室・送信の 3 箇所）を撤去 |
-| `src/features/chat/components/EntryForm/index.tsx` | `prefetchClientIP` のプリフェッチ配線を撤去 |
-| `src/shared/utils/clientInfo.ts` | **削除**（外部 IP サービス依存もろとも消滅） |
-| `src/shared/utils/index.ts` | `clientInfo` の barrel export を削除 |
+| ファイル                                           | 変更                                                                                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/features/chat/api/chatApi.ts`                 | `saveChatLogOptimistic` / `saveChatLog` / `saveChatLogFireAndForget` を `functions.invoke('save-chat')` 経由に。`ip`/`ua` を送らない |
+| `src/features/chat/hooks/useChatHandlers.ts`       | `getClientIP` / `getUserAgent` 取得（入室・退室・送信の 3 箇所）を撤去                                                               |
+| `src/features/chat/components/EntryForm/index.tsx` | `prefetchClientIP` のプリフェッチ配線を撤去                                                                                          |
+| `src/shared/utils/clientInfo.ts`                   | **削除**（外部 IP サービス依存もろとも消滅）                                                                                         |
+| `src/shared/utils/index.ts`                        | `clientInfo` の barrel export を削除                                                                                                 |
 
 ### テスト / 設定
 
-| ファイル | 変更 |
-|---|---|
-| `src/test/setup.ts` | `supabase.functions.invoke` の既定モックを追加 |
+| ファイル                                | 変更                                                         |
+| --------------------------------------- | ------------------------------------------------------------ |
+| `src/test/setup.ts`                     | `supabase.functions.invoke` の既定モックを追加               |
 | `src/features/chat/api/chatApi.test.ts` | 「`ip`/`ua` を送らない」「Edge エラーの伝播」の 2 ケース追加 |
-| `src/App.test.tsx` | 不要になった `clientInfo` モックを削除 |
-| `eslint.config.js` | `supabase/functions`（Deno）を lint 対象から除外 |
-| `CLAUDE.md` | データフロー・Supabase Integration の記述を更新 |
+| `src/App.test.tsx`                      | 不要になった `clientInfo` モックを削除                       |
+| `eslint.config.js`                      | `supabase/functions`（Deno）を lint 対象から除外             |
+| `CLAUDE.md`                             | データフロー・Supabase Integration の記述を更新              |
 
 ---
 

--- a/src/features/chat/hooks/useParticipants.ts
+++ b/src/features/chat/hooks/useParticipants.ts
@@ -1,52 +1,8 @@
 import { useDeferredValue, useMemo } from 'react';
-import type { Chat, Participant } from '@features/chat/types';
+import type { Chat } from '@features/chat/types';
+import { getRecentParticipants } from '@features/chat/utils/participants';
 
-const WELCOME_PATTERN = /^(.+?)\sさん、Welcome to/;
-const EXIT_PATTERN = /^(.+?)さん、またきておくれやすぅ/;
-
-/**
- * 直近5分以内のメッセージから参加者リストを抽出する。
- * 通常発言に加え、管理人の入室メッセージ（"{name} さん、Welcome to..."）も参加者として計上する。
- * 退室メッセージ（"{name}さん、またきておくれやすぅ"）が後に来た場合は除外する。
- */
-export function getRecentParticipants(chatLog: Chat[]): Participant[] {
-  const now = Date.now();
-  const WINDOW_MS = 5 * 60 * 1000;
-
-  // 時刻順にマップへ追加・削除していく
-  const map = new Map<string, Participant>();
-
-  // 時刻昇順にソートして処理（古い順→新しい順）
-  const recentChats = chatLog
-    .filter((c) => now - c.time <= WINDOW_MS)
-    .slice()
-    .sort((a, b) => a.time - b.time);
-
-  for (const c of recentChats) {
-    if (c.metadata?.kind === 'admin') {
-      // 管理人の入室メッセージから参加者を抽出
-      const enterMatch = c.message.match(WELCOME_PATTERN);
-      if (enterMatch) {
-        const name = enterMatch[1].trim();
-        const color = c.metadata.userColor ?? '#333333';
-        map.set(name, { uuid: c.uuid, name, color });
-        continue;
-      }
-      // 退室メッセージなら参加者から除外
-      const exitMatch = c.message.match(EXIT_PATTERN);
-      if (exitMatch) {
-        const name = exitMatch[1].trim();
-        map.delete(name);
-        continue;
-      }
-    } else if (c.name && c.color && !c.system) {
-      // 通常発言: 発言者を参加者として登録
-      map.set(c.name, { uuid: c.uuid, name: c.name, color: c.color });
-    }
-  }
-
-  return Array.from(map.values());
-}
+export { getRecentParticipants } from '@features/chat/utils/participants';
 
 export function useParticipants(chatLog: Chat[]) {
   const deferredChatLog = useDeferredValue(chatLog);

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -97,7 +97,7 @@ export type ChatMetadata = {
   version: 1;
   fontStyle?: FontStyleMetadata;
   avatar?: Exclude<AvatarId, 'none'>;
-  kind?: 'normal' | 'fortune' | 'admin';
+  kind?: 'normal' | 'fortune' | 'admin' | 'bot';
   /** 管理人メッセージ用: 対象ユーザーの色（レガシーの orangered 等を再現） */
   userColor?: string;
   /**

--- a/src/features/chat/utils/normalizeMetadata.test.ts
+++ b/src/features/chat/utils/normalizeMetadata.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { normalizeChatMetadata, normalizeChat } from './normalizeMetadata';
+
+const VALID_KINDS = ['normal', 'fortune', 'admin', 'bot'] as const;
+
+describe('normalizeChatMetadata', () => {
+  describe('基本的な正規化', () => {
+    it('version:1 以外は undefined を返す', () => {
+      expect(normalizeChatMetadata({ version: 2 })).toBeUndefined();
+      expect(normalizeChatMetadata({ version: 0 })).toBeUndefined();
+      expect(normalizeChatMetadata(null)).toBeUndefined();
+    });
+
+    it('有効な kind を保持する', () => {
+      for (const kind of VALID_KINDS) {
+        const result = normalizeChatMetadata({ version: 1, kind });
+        expect(result?.kind).toBe(kind);
+      }
+    });
+  });
+
+  // Feature: chat-llm-bot, Property 1: Bot 種別ラベルの正規化保持
+  // kind:'bot' を含む行は正規化後も kind === 'bot' を保持する (R1.2, R1.4)
+  describe('Property 1: Bot 種別ラベルの正規化保持', () => {
+    it('kind:bot は正規化後も保持される', () => {
+      const result = normalizeChatMetadata({ version: 1, kind: 'bot' });
+      expect(result?.kind).toBe('bot');
+    });
+
+    it('任意の他フィールドと組み合わせても kind:bot を保持する', () => {
+      fc.assert(
+        fc.property(
+          fc.record({
+            fontColor: fc.option(fc.constantFrom('red', 'blue', 'green'), { nil: undefined }),
+            bold: fc.option(fc.boolean(), { nil: undefined }),
+            userColor: fc.option(fc.string(), { nil: undefined }),
+          }),
+          (extra) => {
+            const input = { version: 1, kind: 'bot', ...extra };
+            const result = normalizeChatMetadata(input);
+            return result?.kind === 'bot';
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  // Feature: chat-llm-bot, Property 2: 未知の種別ラベルの破棄
+  // 許可リスト外の kind は undefined になる (R1.3)
+  describe('Property 2: 未知の種別ラベルの破棄', () => {
+    it('許可リスト外の kind は undefined になる', () => {
+      fc.assert(
+        fc.property(
+          fc.string().filter((s) => !VALID_KINDS.includes(s as (typeof VALID_KINDS)[number])),
+          (unknownKind) => {
+            const result = normalizeChatMetadata({ version: 1, kind: unknownKind });
+            return result?.kind === undefined;
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+
+    it('空文字の kind は undefined になる', () => {
+      const result = normalizeChatMetadata({ version: 1, kind: '' });
+      expect(result?.kind).toBeUndefined();
+    });
+
+    it('数値の kind は undefined になる', () => {
+      const result = normalizeChatMetadata({ version: 1, kind: 42 });
+      expect(result?.kind).toBeUndefined();
+    });
+  });
+});
+
+describe('normalizeChat', () => {
+  it('kind:bot の行を Realtime 受信した場合も kind を保持する (R1.4)', () => {
+    const row = {
+      uuid: 'test-uuid',
+      room_id: 'superbeginner',
+      name: 'ゆいボット',
+      color: '#9b59b6',
+      message: 'こんにちは',
+      time: Date.now(),
+      ip: '',
+      ua: 'bot-respond',
+      metadata: { version: 1, kind: 'bot' },
+    };
+    const result = normalizeChat(row);
+    expect(result.metadata?.kind).toBe('bot');
+  });
+});

--- a/src/features/chat/utils/normalizeMetadata.ts
+++ b/src/features/chat/utils/normalizeMetadata.ts
@@ -14,6 +14,8 @@ import { DEFAULT_ROOM_ID, isRoomId } from '../rooms';
 const FONT_SIZES = new Set<number>([1, 2, 3, 4, 5]);
 const COLOR_SET = new Set<string>(FONT_COLOR_NAMES);
 const AVATAR_SET = new Set<string>(AVATAR_IDS);
+// ChatMetadata['kind'] の union から Set を生成することで、型追加時に必ずここも更新が必要になる
+const VALID_KINDS = new Set<NonNullable<ChatMetadata['kind']>>(['normal', 'fortune', 'admin', 'bot']);
 
 export function isFontSize(value: unknown): value is FontSize {
   return typeof value === 'number' && FONT_SIZES.has(value);
@@ -75,8 +77,8 @@ export function normalizeChatMetadata(input: unknown): ChatMetadata | undefined 
       result.avatar = input.avatar;
     }
 
-    if (input.kind === 'normal' || input.kind === 'fortune' || input.kind === 'admin') {
-      result.kind = input.kind;
+    if (typeof input.kind === 'string' && VALID_KINDS.has(input.kind)) {
+      result.kind = input.kind as ChatMetadata['kind'];
     }
 
     if (typeof input.userColor === 'string') {

--- a/src/features/chat/utils/participants.equivalence.test.ts
+++ b/src/features/chat/utils/participants.equivalence.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'vitest';
+import * as fc from 'fast-check';
+import { getRecentParticipants as srcImpl, RECENT_WINDOW_MS } from './participants';
+import { getRecentParticipants as sharedImpl } from '../../../../supabase/functions/_shared/participants';
+
+const VALID_KINDS = ['normal', 'fortune', 'admin', 'bot', undefined] as const;
+const now = 1_700_000_000_000;
+
+// Feature: chat-llm-bot, Property 10: 実装等価性
+// src 版と _shared 版の getRecentParticipants が同一結果を返す (R5.7)
+describe('getRecentParticipants 両実装等価性', () => {
+  it('任意の入力で src 版と _shared 版が同一の参加者集合を返す (PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            uuid: fc.string({ minLength: 1, maxLength: 8 }),
+            name: fc.string({ minLength: 0, maxLength: 10 }),
+            color: fc.string({ minLength: 0, maxLength: 10 }),
+            message: fc.oneof(
+              fc.constant('こんにちは'),
+              fc.string({ minLength: 0, maxLength: 20 }),
+              fc.constantFrom(
+                'alice さん、Welcome to superbeginner!',
+                'aliceさん、またきておくれやすぅ',
+                'bob さん、Welcome to beginner!',
+              ),
+            ),
+            time: fc.integer({ min: now - RECENT_WINDOW_MS - 5000, max: now }),
+            system: fc.option(fc.boolean(), { nil: undefined }),
+            metadata: fc.option(
+              fc.record({
+                kind: fc.option(fc.constantFrom(...VALID_KINDS), { nil: undefined }),
+                userColor: fc.option(fc.string(), { nil: undefined }),
+              }),
+              { nil: null },
+            ),
+          }),
+          { maxLength: 20 },
+        ),
+        fc.integer({ min: now, max: now + 10000 }),
+        (logs, testNow) => {
+          const srcResult = srcImpl(logs, testNow);
+          const sharedResult = sharedImpl(logs, testNow);
+
+          const srcNames = new Set(srcResult.map((p) => p.name));
+          const sharedNames = new Set(sharedResult.map((p) => p.name));
+
+          if (srcNames.size !== sharedNames.size) return false;
+          return [...srcNames].every((n) => sharedNames.has(n));
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/features/chat/utils/participants.test.ts
+++ b/src/features/chat/utils/participants.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { getRecentParticipants, RECENT_WINDOW_MS, type ParticipantRow } from './participants';
+
+const now = 1_700_000_000_000;
+const recent = (offset = 0): number => now - offset;
+
+function normalUser(name: string, color = '#ffffff'): ParticipantRow {
+  return { uuid: `uuid-${name}`, name, color, message: 'hello', time: recent() };
+}
+
+function adminWelcome(name: string, userColor?: string): ParticipantRow {
+  return {
+    uuid: `uuid-welcome-${name}`,
+    name: 'admin',
+    color: '#000',
+    message: `${name} さん、Welcome to superbeginner!`,
+    time: recent(),
+    metadata: { kind: 'admin', userColor },
+  };
+}
+
+function adminExit(name: string): ParticipantRow {
+  return {
+    uuid: `uuid-exit-${name}`,
+    name: 'admin',
+    color: '#000',
+    message: `${name}さん、またきておくれやすぅ`,
+    time: recent(),
+    metadata: { kind: 'admin' },
+  };
+}
+
+function botMessage(name = 'ゆいボット'): ParticipantRow {
+  return {
+    uuid: 'uuid-bot',
+    name,
+    color: '#9b59b6',
+    message: 'こんにちは',
+    time: recent(),
+    metadata: { kind: 'bot' },
+  };
+}
+
+// Feature: chat-llm-bot, Property 10: 参加者判定ロジックの正しさ
+describe('getRecentParticipants', () => {
+  describe('時間窓', () => {
+    it('5分以内の通常発言者は参加者に含まれる', () => {
+      const logs: ParticipantRow[] = [normalUser('alice')];
+      expect(getRecentParticipants(logs, now)).toHaveLength(1);
+    });
+
+    it('5分超過の発言者は参加者に含まれない (R5.3)', () => {
+      const old: ParticipantRow = {
+        ...normalUser('alice'),
+        time: now - RECENT_WINDOW_MS - 1,
+      };
+      expect(getRecentParticipants([old], now)).toHaveLength(0);
+    });
+
+    it('5分ちょうど(境界)の発言者は含まれる', () => {
+      const boundary: ParticipantRow = {
+        ...normalUser('alice'),
+        time: now - RECENT_WINDOW_MS,
+      };
+      expect(getRecentParticipants([boundary], now)).toHaveLength(1);
+    });
+
+    it('任意の now で5分超過の発言は結果に影響しない (PBT)', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 1_000_000 }),
+          (nowOffset) => {
+            const testNow = now + nowOffset;
+            const oldLog: ParticipantRow = {
+              ...normalUser('old-user'),
+              time: testNow - RECENT_WINDOW_MS - 1000,
+            };
+            const result = getRecentParticipants([oldLog], testNow);
+            return result.length === 0;
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe('入室追加 (R5.4)', () => {
+    it('kind:admin の入室メッセージから参加者を追加する', () => {
+      const result = getRecentParticipants([adminWelcome('alice', '#ff0000')], now);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('alice');
+      expect(result[0].color).toBe('#ff0000');
+    });
+
+    it('userColor なしは #333333 をデフォルトで使用する', () => {
+      const result = getRecentParticipants([adminWelcome('bob')], now);
+      expect(result[0].color).toBe('#333333');
+    });
+  });
+
+  describe('退室除外 (R5.5)', () => {
+    it('入室後に退室メッセージが来た名前は除外される', () => {
+      const logs: ParticipantRow[] = [
+        { ...adminWelcome('alice'), time: recent(2000) },
+        { ...adminExit('alice'), time: recent(1000) },
+      ];
+      expect(getRecentParticipants(logs, now)).toHaveLength(0);
+    });
+
+    it('退室後に再入室した場合は再追加される', () => {
+      const logs: ParticipantRow[] = [
+        { ...adminWelcome('alice'), time: recent(4000) },
+        { ...adminExit('alice'), time: recent(3000) },
+        { ...adminWelcome('alice'), time: recent(2000) },
+      ];
+      const result = getRecentParticipants(logs, now);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('alice');
+    });
+  });
+
+  describe('Bot 非計上 (R5.6)', () => {
+    it('kind:bot の発言者は実ユーザーとして計上されない', () => {
+      const result = getRecentParticipants([botMessage()], now);
+      expect(result).toHaveLength(0);
+    });
+
+    it('Bot 発言を追加しても実ユーザー集合は変化しない (PBT)', () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.record({
+              name: fc.string({ minLength: 1, maxLength: 10 }),
+              time: fc.integer({ min: now - RECENT_WINDOW_MS + 1000, max: now }),
+            }),
+          ),
+          (users) => {
+            const userLogs: ParticipantRow[] = users.map((u) => ({
+              uuid: `u-${u.name}`,
+              name: u.name,
+              color: '#ffffff',
+              message: 'hello',
+              time: u.time,
+            }));
+            const withBot = [
+              ...userLogs,
+              { ...botMessage(), time: now - 1000 },
+            ];
+            const withoutBot = getRecentParticipants(userLogs, now);
+            const withBotResult = getRecentParticipants(withBot, now);
+            const withoutBotNames = new Set(withoutBot.map((p) => p.name));
+            const withBotNames = new Set(withBotResult.map((p) => p.name));
+            return (
+              withoutBotNames.size === withBotNames.size &&
+              [...withoutBotNames].every((n) => withBotNames.has(n))
+            );
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
+  });
+
+  describe('通常発言', () => {
+    it('system:true の発言は参加者に含まれない', () => {
+      const sys: ParticipantRow = { ...normalUser('alice'), system: true };
+      expect(getRecentParticipants([sys], now)).toHaveLength(0);
+    });
+
+    it('name が空の発言は参加者に含まれない', () => {
+      const noName: ParticipantRow = { ...normalUser(''), uuid: 'uuid-noname' };
+      expect(getRecentParticipants([noName], now)).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/chat/utils/participants.ts
+++ b/src/features/chat/utils/participants.ts
@@ -1,0 +1,50 @@
+import type { Participant } from '@features/chat/types';
+
+export { type Participant };
+export const RECENT_WINDOW_MS = 5 * 60 * 1000;
+
+const WELCOME_PATTERN = /^(.+?)\sさん、Welcome to/;
+const EXIT_PATTERN = /^(.+?)さん、またきておくれやすぅ/;
+
+export type ParticipantRow = {
+  uuid: string;
+  name: string;
+  color: string;
+  message: string;
+  time: number;
+  system?: boolean;
+  metadata?: { kind?: string; userColor?: string } | null;
+};
+
+export function getRecentParticipants(
+  chatLog: ParticipantRow[],
+  now: number = Date.now(),
+): Participant[] {
+  const map = new Map<string, Participant>();
+  const recent = chatLog
+    .filter((c) => now - c.time <= RECENT_WINDOW_MS)
+    .slice()
+    .sort((a, b) => a.time - b.time);
+
+  for (const c of recent) {
+    if (c.metadata?.kind === 'bot') continue; // Bot は実ユーザーに数えない (R5.6)
+    if (c.metadata?.kind === 'admin') {
+      const enterMatch = c.message.match(WELCOME_PATTERN);
+      if (enterMatch) {
+        const name = enterMatch[1].trim();
+        const color = c.metadata.userColor ?? '#333333';
+        map.set(name, { uuid: c.uuid, name, color });
+        continue;
+      }
+      const exitMatch = c.message.match(EXIT_PATTERN);
+      if (exitMatch) {
+        map.delete(exitMatch[1].trim());
+        continue;
+      }
+    } else if (c.name && c.color && !c.system) {
+      map.set(c.name, { uuid: c.uuid, name: c.name, color: c.color });
+    }
+  }
+
+  return Array.from(map.values());
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,3 +17,8 @@ major_version = 17
 # 匿名チャットのため JWT 検証は無効（anon key での invoke を許可）。
 # ip / ua はリクエストヘッダから取得し service_role で INSERT する。
 verify_jwt = false
+
+[functions.bot-respond]
+# Webhook(pg_net)からのサーバー間呼び出しで起動される。ブラウザからは呼ばれない。
+# 軽量認証は BOT_WEBHOOK_SECRET のヘッダ照合で別途行う(verify_jwt とは独立)。
+verify_jwt = false

--- a/supabase/functions/_shared/botConfig.test.ts
+++ b/supabase/functions/_shared/botConfig.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadBotConfig } from './botConfig.ts';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('BOT_') || key === 'OPENAI_API_KEY') {
+      delete process.env[key];
+    }
+  }
+});
+
+afterEach(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+describe('loadBotConfig', () => {
+  describe('既定値', () => {
+    it('環境変数なしで既定値を返す', () => {
+      const config = loadBotConfig();
+      expect(config.targetRoom).toBe('superbeginner');
+      expect(config.greetings).toEqual(['こんにちは']);
+      expect(config.cooldownMinMs).toBe(8000);
+      expect(config.cooldownMaxMs).toBe(15000);
+      expect(config.responseDelayMinMs).toBe(2000);
+      expect(config.responseDelayMaxMs).toBe(6000);
+      expect(config.historyMessageCap).toBe(20);
+      expect(config.botName).toBe('ゆいボット');
+      expect(config.botColor).toBe('#9b59b6');
+      expect(config.model).toBe('gpt-4o-mini');
+      expect(config.webhookSecret).toBeNull();
+      expect(config.openaiApiKey).toBe('');
+    });
+  });
+
+  describe('環境変数からの読み込み', () => {
+    it('BOT_TARGET_ROOM を読み込む', () => {
+      process.env.BOT_TARGET_ROOM = 'beginner';
+      expect(loadBotConfig().targetRoom).toBe('beginner');
+    });
+
+    it('OPENAI_API_KEY を読み込む', () => {
+      process.env.OPENAI_API_KEY = 'sk-test-key';
+      expect(loadBotConfig().openaiApiKey).toBe('sk-test-key');
+    });
+
+    it('BOT_COOLDOWN_MIN_MS を数値に変換する', () => {
+      process.env.BOT_COOLDOWN_MIN_MS = '5000';
+      expect(loadBotConfig().cooldownMinMs).toBe(5000);
+    });
+
+    it('BOT_HISTORY_MESSAGE_CAP=0 を正しく処理する (R8.6)', () => {
+      process.env.BOT_HISTORY_MESSAGE_CAP = '0';
+      expect(loadBotConfig().historyMessageCap).toBe(0);
+    });
+
+    it('BOT_TEMPERATURE を浮動小数点数に変換する', () => {
+      process.env.BOT_TEMPERATURE = '1.0';
+      expect(loadBotConfig().temperature).toBe(1.0);
+    });
+
+    it('BOT_TEMPERATURE 未設定は 0.7 を返す', () => {
+      expect(loadBotConfig().temperature).toBe(0.7);
+    });
+
+    it('不正な整数値は既定値にフォールバックする', () => {
+      process.env.BOT_COOLDOWN_MIN_MS = 'invalid';
+      expect(loadBotConfig().cooldownMinMs).toBe(8000);
+    });
+
+    it('BOT_WEBHOOK_SECRET を読み込む', () => {
+      process.env.BOT_WEBHOOK_SECRET = 'my-secret';
+      expect(loadBotConfig().webhookSecret).toBe('my-secret');
+    });
+  });
+
+  describe('BOT_GREETINGS のパース', () => {
+    it('改行区切りの文字列をパースする', () => {
+      process.env.BOT_GREETINGS = 'こんにちは\nよろしくね';
+      expect(loadBotConfig().greetings).toEqual(['こんにちは', 'よろしくね']);
+    });
+
+    it('JSON 配列をパースする', () => {
+      process.env.BOT_GREETINGS = '["hello","world"]';
+      expect(loadBotConfig().greetings).toEqual(['hello', 'world']);
+    });
+
+    it('空の値は既定の挨拶を返す', () => {
+      process.env.BOT_GREETINGS = '';
+      expect(loadBotConfig().greetings).toEqual(['こんにちは']);
+    });
+
+    it('単一の挨拶文字列は配列として返す', () => {
+      process.env.BOT_GREETINGS = 'いらっしゃい';
+      expect(loadBotConfig().greetings).toEqual(['いらっしゃい']);
+    });
+  });
+});

--- a/supabase/functions/_shared/botConfig.ts
+++ b/supabase/functions/_shared/botConfig.ts
@@ -1,0 +1,66 @@
+export type BotConfig = {
+  targetRoom: string;
+  greetings: string[];
+  cooldownMinMs: number;
+  cooldownMaxMs: number;
+  responseDelayMinMs: number;
+  responseDelayMaxMs: number;
+  historyMessageCap: number;
+  botName: string;
+  botColor: string;
+  model: string;
+  temperature: number;
+  systemPrompt: string;
+  webhookSecret: string | null;
+  openaiApiKey: string;
+};
+
+function parsePositiveInt(value: string | undefined, defaultVal: number): number {
+  if (value === undefined) return defaultVal;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? n : defaultVal;
+}
+
+function parseFloatParam(value: string | undefined, defaultVal: number): number {
+  if (value === undefined) return defaultVal;
+  const n = parseFloat(value);
+  return Number.isFinite(n) && n >= 0 ? n : defaultVal;
+}
+
+function parseGreetings(value: string | undefined): string[] {
+  if (!value) return ['こんにちは'];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
+      return parsed.length > 0 ? parsed : ['こんにちは'];
+    }
+  } catch {
+    // JSON でなければ改行区切りとして扱う
+  }
+  const lines = value.split('\n').map((s) => s.trim()).filter(Boolean);
+  return lines.length > 0 ? lines : ['こんにちは'];
+}
+
+export function loadBotConfig(): BotConfig {
+  const env = (key: string) =>
+    typeof Deno !== 'undefined' ? Deno.env.get(key) : process.env[key];
+
+  return {
+    targetRoom: env('BOT_TARGET_ROOM') ?? 'superbeginner',
+    greetings: parseGreetings(env('BOT_GREETINGS')),
+    cooldownMinMs: parsePositiveInt(env('BOT_COOLDOWN_MIN_MS'), 8000),
+    cooldownMaxMs: parsePositiveInt(env('BOT_COOLDOWN_MAX_MS'), 15000),
+    responseDelayMinMs: parsePositiveInt(env('BOT_RESPONSE_DELAY_MIN_MS'), 2000),
+    responseDelayMaxMs: parsePositiveInt(env('BOT_RESPONSE_DELAY_MAX_MS'), 6000),
+    historyMessageCap: parsePositiveInt(env('BOT_HISTORY_MESSAGE_CAP'), 20),
+    botName: env('BOT_NAME') ?? 'ゆいボット',
+    botColor: env('BOT_COLOR') ?? '#9b59b6',
+    model: env('BOT_MODEL') ?? 'gpt-4o-mini',
+    temperature: parseFloatParam(env('BOT_TEMPERATURE'), 0.7),
+    systemPrompt:
+      env('BOT_SYSTEM_PROMPT') ??
+      'あなたはゆいちゃっとのアシスタントボットです。丁寧な日本語で短く返答してください。',
+    webhookSecret: env('BOT_WEBHOOK_SECRET') ?? null,
+    openaiApiKey: env('OPENAI_API_KEY') ?? '',
+  };
+}

--- a/supabase/functions/_shared/buildHistory.test.ts
+++ b/supabase/functions/_shared/buildHistory.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { buildHistory } from './buildHistory.ts';
+import { RECENT_WINDOW_MS } from './participants.ts';
+
+const now = 1_700_000_000_000;
+
+function userLog(name = 'alice', offset = 1000) {
+  return { uuid: `u-${name}`, name, color: '#fff', message: `hi from ${name}`, time: now - offset };
+}
+
+function botLog(offset = 500) {
+  return {
+    uuid: 'bot',
+    name: 'ゆいボット',
+    color: '#9b59b6',
+    message: 'こんにちは',
+    time: now - offset,
+    metadata: { kind: 'bot' as const },
+  };
+}
+
+// Feature: chat-llm-bot, Property 8: 履歴トークン上限の不変条件
+// buildHistory(logs, cap, now).length <= cap、cap===0 で空配列 (R3.8, R8.5, R8.6)
+describe('Property 8: 履歴トークン上限の不変条件', () => {
+  it('cap=0 の場合は空配列を返す (R8.6)', () => {
+    const logs = [userLog(), botLog()];
+    expect(buildHistory(logs, 0, now)).toEqual([]);
+  });
+
+  it('任意の cap >= 0 で history.length <= cap (PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 100 }),
+        fc.array(
+          fc.record({
+            uuid: fc.string({ minLength: 1 }),
+            name: fc.string({ minLength: 1, maxLength: 10 }),
+            color: fc.string(),
+            message: fc.string({ minLength: 0, maxLength: 50 }),
+            time: fc.integer({ min: now - RECENT_WINDOW_MS + 1000, max: now }),
+          }),
+          { maxLength: 50 },
+        ),
+        (cap, logs) => {
+          const history = buildHistory(logs, cap, now);
+          return history.length <= cap;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('Bot 発言は assistant ロールにマップされる', () => {
+    const history = buildHistory([botLog()], 5, now);
+    expect(history[0]?.role).toBe('assistant');
+  });
+
+  it('通常ユーザー発言は user ロールにマップされる', () => {
+    const history = buildHistory([userLog()], 5, now);
+    expect(history[0]?.role).toBe('user');
+  });
+
+  it('5分超過の発言は履歴に含まれない', () => {
+    const oldLog = { ...userLog('old'), time: now - RECENT_WINDOW_MS - 1000 };
+    const history = buildHistory([oldLog], 10, now);
+    expect(history).toHaveLength(0);
+  });
+
+  it('system/admin/fortune の発言は履歴に含まれない', () => {
+    const adminLog = {
+      uuid: 'admin-msg',
+      name: 'admin',
+      color: '#000',
+      message: 'alice さん、Welcome to superbeginner!',
+      time: now - 1000,
+      metadata: { kind: 'admin' as const },
+    };
+    const history = buildHistory([adminLog], 10, now);
+    expect(history).toHaveLength(0);
+  });
+
+  it('cap より多いログは最新の cap 件に絞られる', () => {
+    const logs = Array.from({ length: 10 }, (_, i) => userLog(`user${i}`, (10 - i) * 1000));
+    const history = buildHistory(logs, 3, now);
+    expect(history).toHaveLength(3);
+  });
+});

--- a/supabase/functions/_shared/buildHistory.ts
+++ b/supabase/functions/_shared/buildHistory.ts
@@ -1,0 +1,37 @@
+import { RECENT_WINDOW_MS, type ParticipantRow } from './participants.ts';
+
+export type OpenAIMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+/**
+ * 直近ログから OpenAI へ渡す会話履歴を整形する。
+ * cap 件までに制限し、Bot 発言を assistant、実ユーザー発言を user にマップする。
+ * cap === 0 の場合は空配列を返す (R8.6)。
+ */
+export function buildHistory(
+  logs: ParticipantRow[],
+  cap: number,
+  now: number = Date.now(),
+): OpenAIMessage[] {
+  if (cap <= 0) return [];
+
+  const recent = logs
+    .filter(
+      (c) =>
+        now - c.time <= RECENT_WINDOW_MS &&
+        !c.system &&
+        c.metadata?.kind !== 'admin' &&
+        c.metadata?.kind !== 'fortune',
+    )
+    .slice()
+    .sort((a, b) => a.time - b.time);
+
+  const sliced = recent.length > cap ? recent.slice(recent.length - cap) : recent;
+
+  return sliced.map((c) => ({
+    role: c.metadata?.kind === 'bot' ? 'assistant' : 'user',
+    content: c.name ? `${c.name}: ${c.message}` : c.message,
+  }));
+}

--- a/supabase/functions/_shared/decideBotAction.cooldown.test.ts
+++ b/supabase/functions/_shared/decideBotAction.cooldown.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+
+const defaultConfig: BotConfig = {
+  targetRoom: 'superbeginner',
+  greetings: ['こんにちは'],
+  cooldownMinMs: 8000,
+  cooldownMaxMs: 15000,
+  responseDelayMinMs: 2000,
+  responseDelayMaxMs: 6000,
+  historyMessageCap: 20,
+  botName: 'ゆいボット',
+  botColor: '#9b59b6',
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  systemPrompt: 'テスト',
+  webhookSecret: null,
+  openaiApiKey: 'sk-test',
+};
+
+function userLog(name = 'alice', timeOffset = 2000) {
+  return {
+    uuid: `u-${name}`,
+    name,
+    color: '#ffffff',
+    message: 'hello',
+    time: now - timeOffset,
+  };
+}
+
+function botLog(timeOffset = 1000) {
+  return {
+    uuid: 'bot-msg',
+    name: 'ゆいボット',
+    color: '#9b59b6',
+    message: 'こんにちは',
+    time: now - timeOffset,
+    metadata: { kind: 'bot' as const },
+  };
+}
+
+function triggerRecord(): TriggerRecord {
+  return {
+    uuid: 'trigger',
+    room_id: 'superbeginner',
+    name: 'alice',
+    color: '#ffffff',
+    message: 'テスト発言',
+    time: now - 100,
+    metadata: { kind: 'normal' },
+  };
+}
+
+// Feature: chat-llm-bot, Property 6: クールダウン不変条件と応答の集約
+// now - lastBotTime < cooldown の窓内では respond を返さない (R8.1, R8.3, R8.4, R8.7)
+describe('Property 6: クールダウン不変条件と応答の集約', () => {
+  it('クールダウン窓内(最終Bot発言から 0ms)では respond を返さない', () => {
+    // rng を固定(cooldown = cooldownMin = 8000ms、lastBotTime = now - 100)
+    const logs = [userLog(), botLog(100)];
+    const action = decideBotAction(triggerRecord(), logs, defaultConfig, now, () => 0);
+    // now - (now - 100) = 100 < 8000 → cooldown
+    expect(action.type).toBe('ignore');
+  });
+
+  it('クールダウン経過後(rng=0 → cooldown=cooldownMin)は respond を返す', () => {
+    const elapsedMs = defaultConfig.cooldownMinMs + 1000;
+    const logs = [userLog(), botLog(elapsedMs)];
+    const action = decideBotAction(triggerRecord(), logs, defaultConfig, now, () => 0);
+    expect(action.type).toBe('respond');
+  });
+
+  it('クールダウン窓内に複数発言が来ても respond は 0 回(集約 R8.4, PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 10 }),
+        (msgCount) => {
+          // 最終 Bot 発言が直近(クールダウン未経過)
+          const logs = [
+            ...Array.from({ length: msgCount }, (_, i) => userLog(`user${i}`, 5000 + i * 100)),
+            botLog(100), // 直近の Bot 発言(経過 100ms)
+          ];
+          // rng=0 → cooldown = cooldownMin = 8000ms。100 < 8000 → ignore
+          const action = decideBotAction(triggerRecord(), logs, defaultConfig, now, () => 0);
+          return action.type === 'ignore';
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it('クールダウンは直近ログの Bot 発言時刻のみから導出される(外部状態不要) R8.7', () => {
+    const logs1 = [userLog(), botLog(9000)]; // 9000ms 経過
+    const logs2 = [userLog(), botLog(9000)]; // 同じ入力
+    const action1 = decideBotAction(triggerRecord(), logs1, defaultConfig, now, () => 0);
+    const action2 = decideBotAction(triggerRecord(), logs2, defaultConfig, now, () => 0);
+    expect(action1.type).toBe(action2.type);
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.gate.test.ts
+++ b/supabase/functions/_shared/decideBotAction.gate.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+
+const defaultConfig: BotConfig = {
+  targetRoom: 'superbeginner',
+  greetings: ['こんにちは'],
+  cooldownMinMs: 8000,
+  cooldownMaxMs: 15000,
+  responseDelayMinMs: 2000,
+  responseDelayMaxMs: 6000,
+  historyMessageCap: 20,
+  botName: 'ゆいボット',
+  botColor: '#9b59b6',
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  systemPrompt: 'テスト',
+  webhookSecret: null,
+  openaiApiKey: 'sk-test',
+};
+
+function normalRecord(): TriggerRecord {
+  return {
+    uuid: 'test',
+    room_id: 'superbeginner',
+    name: 'alice',
+    color: '#ffffff',
+    message: 'こんにちは',
+    time: now - 1000,
+    metadata: { kind: 'normal' },
+  };
+}
+
+// Feature: chat-llm-bot, Property 4: 実ユーザー在室ゲート
+// 実ユーザー0人の直近ログでは greet も respond も返さない (R3.6, R5.1, R6.1, R6.3)
+describe('Property 4: 実ユーザー在室ゲート', () => {
+  it('空の直近ログでは no-real-user を返す', () => {
+    const action = decideBotAction(normalRecord(), [], defaultConfig, now);
+    expect(action.type).toBe('ignore');
+    expect((action as { type: 'ignore'; reason: string }).reason).toBe('no-real-user');
+  });
+
+  it('Bot 発言のみのログでは no-real-user を返す', () => {
+    const botOnly = [{
+      uuid: 'bot-msg',
+      name: 'ゆいボット',
+      color: '#9b59b6',
+      message: 'こんにちは',
+      time: now - 1000,
+      metadata: { kind: 'bot' as const },
+    }];
+    const action = decideBotAction(normalRecord(), botOnly, defaultConfig, now);
+    expect(action.type).toBe('ignore');
+    expect((action as { type: 'ignore'; reason: string }).reason).toBe('no-real-user');
+  });
+
+  it('任意の「実ユーザー0人ログ」で greet/respond を返さない (PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            uuid: fc.string({ minLength: 1 }),
+            name: fc.string({ minLength: 1, maxLength: 10 }),
+            color: fc.string(),
+            message: fc.string(),
+            time: fc.integer({ min: now - 5 * 60 * 1000, max: now }),
+          }),
+        ),
+        (botLogs) => {
+          // Bot 発言のみのログ
+          const logs = botLogs.map((l) => ({ ...l, metadata: { kind: 'bot' as const } }));
+          const action = decideBotAction(normalRecord(), logs, defaultConfig, now);
+          return action.type === 'ignore' && (action as { reason: string }).reason === 'no-real-user';
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.greet.test.ts
+++ b/supabase/functions/_shared/decideBotAction.greet.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+const WINDOW = 5 * 60 * 1000;
+
+const defaultConfig: BotConfig = {
+  targetRoom: 'superbeginner',
+  greetings: ['こんにちは', 'よろしくね'],
+  cooldownMinMs: 8000,
+  cooldownMaxMs: 15000,
+  responseDelayMinMs: 2000,
+  responseDelayMaxMs: 6000,
+  historyMessageCap: 20,
+  botName: 'ゆいボット',
+  botColor: '#9b59b6',
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  systemPrompt: 'テスト',
+  webhookSecret: null,
+  openaiApiKey: 'sk-test',
+};
+
+function userLog(name: string, timeOffset = 1000) {
+  return {
+    uuid: `u-${name}`,
+    name,
+    color: '#ffffff',
+    message: 'hello',
+    time: now - timeOffset,
+  };
+}
+
+function triggerRecord(): TriggerRecord {
+  return {
+    uuid: 'trigger',
+    room_id: 'superbeginner',
+    name: 'alice',
+    color: '#ffffff',
+    message: 'こんにちは',
+    time: now - 500,
+    metadata: { kind: 'normal' },
+  };
+}
+
+// Feature: chat-llm-bot, Property 5: 冪等な登場と挨拶の連続投稿
+// Bot 発言が直近5分に無ければ greet、1件以上あれば greet を返さない (R2.1-2.6, R10.3)
+describe('Property 5: 冪等な登場と挨拶の連続投稿', () => {
+  it('直近5分に Bot 発言なし → greet を返し messages は greetings に一致する', () => {
+    const logs = [userLog('alice')];
+    const action = decideBotAction(triggerRecord(), logs, defaultConfig, now);
+    expect(action.type).toBe('greet');
+    if (action.type === 'greet') {
+      expect(action.messages).toEqual(defaultConfig.greetings);
+    }
+  });
+
+  it('直近5分に Bot 発言あり → greet を返さない(冪等性)', () => {
+    const logs = [
+      userLog('alice'),
+      {
+        uuid: 'bot-msg',
+        name: 'ゆいボット',
+        color: '#9b59b6',
+        message: 'こんにちは',
+        time: now - 1000,
+        metadata: { kind: 'bot' as const },
+      },
+    ];
+    const action = decideBotAction(triggerRecord(), logs, defaultConfig, now);
+    expect(action.type).not.toBe('greet');
+  });
+
+  it('greet の messages は greetings と順序込みで一致する (R2.4)', () => {
+    const configs = [
+      { ...defaultConfig, greetings: ['hello'] },
+      { ...defaultConfig, greetings: ['hi', 'how are you?', 'let\'s chat!'] },
+    ];
+    for (const config of configs) {
+      const action = decideBotAction(triggerRecord(), [userLog('alice')], config, now);
+      expect(action.type).toBe('greet');
+      if (action.type === 'greet') {
+        expect(action.messages).toEqual(config.greetings);
+        expect(action.messages.length).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  it('登場判定は実ユーザー人数(1人 vs N人)に依存しない (R2.6, PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 10 }),
+        (userCount) => {
+          const manyUsers = Array.from({ length: userCount }, (_, i) => userLog(`user${i}`));
+          const action = decideBotAction(triggerRecord(), manyUsers, defaultConfig, now);
+          return action.type === 'greet';
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it('5分を超えた Bot 発言は登場カウントに含まれない', () => {
+    const oldBot = {
+      uuid: 'old-bot',
+      name: 'ゆいボット',
+      color: '#9b59b6',
+      message: 'こんにちは',
+      time: now - WINDOW - 1000, // 5分超過
+      metadata: { kind: 'bot' as const },
+    };
+    const logs = [userLog('alice'), oldBot];
+    const action = decideBotAction(triggerRecord(), logs, defaultConfig, now);
+    expect(action.type).toBe('greet');
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.loop.test.ts
+++ b/supabase/functions/_shared/decideBotAction.loop.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+
+const defaultConfig: BotConfig = {
+  targetRoom: 'superbeginner',
+  greetings: ['こんにちは'],
+  cooldownMinMs: 8000,
+  cooldownMaxMs: 15000,
+  responseDelayMinMs: 2000,
+  responseDelayMaxMs: 6000,
+  historyMessageCap: 20,
+  botName: 'ゆいボット',
+  botColor: '#9b59b6',
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  systemPrompt: 'テスト用プロンプト',
+  webhookSecret: null,
+  openaiApiKey: 'sk-test',
+};
+
+// Feature: chat-llm-bot, Property 3: ループ防止の不変条件
+// kind:'bot' の record は、ルーム・参加者・クールダウンの状態に関わらず
+// 常に { type: 'ignore', reason: 'loop' } を返す (R4.1, R4.2, R11.3)
+describe('Property 3: ループ防止の不変条件', () => {
+  it('kind:bot の record には常に ignore(loop) を返す', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          uuid: fc.string({ minLength: 1 }),
+          room_id: fc.option(fc.string(), { nil: undefined }),
+          name: fc.string(),
+          color: fc.string(),
+          message: fc.string(),
+          time: fc.integer({ min: 0, max: now }),
+          system: fc.option(fc.boolean(), { nil: undefined }),
+        }),
+        fc.array(
+          fc.record({
+            uuid: fc.string({ minLength: 1 }),
+            name: fc.string({ minLength: 1, maxLength: 10 }),
+            color: fc.string(),
+            message: fc.string(),
+            time: fc.integer({ min: now - 5 * 60 * 1000, max: now }),
+          }),
+        ),
+        fc.record({
+          cooldownMinMs: fc.integer({ min: 0, max: 30000 }),
+          cooldownMaxMs: fc.integer({ min: 0, max: 30000 }),
+        }),
+        (recordBase, recentLogs, configOverride) => {
+          const record: TriggerRecord = {
+            ...recordBase,
+            metadata: { kind: 'bot' },
+          };
+          const config = { ...defaultConfig, ...configOverride };
+          const action = decideBotAction(record, recentLogs, config, now);
+          return action.type === 'ignore' && action.reason === 'loop';
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('クライアントが僭称した kind:bot も同様にループ防止する (R11.3)', () => {
+    const record: TriggerRecord = {
+      uuid: 'spoofed',
+      room_id: 'superbeginner',
+      name: 'spoofer',
+      color: '#fff',
+      message: 'なりすまし',
+      time: now - 1000,
+      metadata: { kind: 'bot' },
+    };
+    const action = decideBotAction(record, [], defaultConfig, now);
+    expect(action.type).toBe('ignore');
+    expect((action as { type: 'ignore'; reason: string }).reason).toBe('loop');
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.respond.test.ts
+++ b/supabase/functions/_shared/decideBotAction.respond.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+
+function makeConfig(overrides: Partial<BotConfig> = {}): BotConfig {
+  return {
+    targetRoom: 'superbeginner',
+    greetings: ['こんにちは'],
+    cooldownMinMs: 8000,
+    cooldownMaxMs: 15000,
+    responseDelayMinMs: 2000,
+    responseDelayMaxMs: 6000,
+    historyMessageCap: 20,
+    botName: 'ゆいボット',
+    botColor: '#9b59b6',
+    model: 'gpt-4o-mini',
+    temperature: 0.7,
+    systemPrompt: 'テスト',
+    webhookSecret: null,
+    openaiApiKey: 'sk-test',
+    ...overrides,
+  };
+}
+
+function recentBotLog(timeOffset: number) {
+  return {
+    uuid: 'bot-msg',
+    name: 'ゆいボット',
+    color: '#9b59b6',
+    message: 'こんにちは',
+    time: now - timeOffset,
+    metadata: { kind: 'bot' as const },
+  };
+}
+
+function userLog(name = 'alice', timeOffset = 2000) {
+  return {
+    uuid: `u-${name}`,
+    name,
+    color: '#ffffff',
+    message: 'hello',
+    time: now - timeOffset,
+  };
+}
+
+function triggerRecord(name = 'alice'): TriggerRecord {
+  return {
+    uuid: 'trigger',
+    room_id: 'superbeginner',
+    name,
+    color: '#ffffff',
+    message: '返して',
+    time: now - 100,
+    metadata: { kind: 'normal' },
+  };
+}
+
+// Feature: chat-llm-bot, Property 9: 応答ゲートと人数非依存の単調性
+// 全条件成立時に { type: 'respond', responseDelayMs, history } を返す (R3.7, R5.1, R5.2, R8.2, R10.3)
+describe('Property 9: 応答ゲートと人数非依存の単調性', () => {
+  it('全条件成立(クールダウン経過・通常発言)で respond を返す', () => {
+    const config = makeConfig();
+    // rng=0 → cooldown = cooldownMinMs = 8000ms。Bot 発言 9000ms 前 → 経過
+    const logs = [userLog(), recentBotLog(9000)];
+    const action = decideBotAction(triggerRecord(), logs, config, now, () => 0);
+    expect(action.type).toBe('respond');
+  });
+
+  it('responseDelayMs は [min, max] 範囲内 (R8.2)', () => {
+    const config = makeConfig();
+    const logs = [userLog(), recentBotLog(20000)];
+    // 複数の rng 値でテスト
+    for (let r = 0; r <= 1; r += 0.1) {
+      const action = decideBotAction(triggerRecord(), logs, config, now, () => r);
+      if (action.type === 'respond') {
+        expect(action.responseDelayMs).toBeGreaterThanOrEqual(config.responseDelayMinMs);
+        expect(action.responseDelayMs).toBeLessThanOrEqual(config.responseDelayMaxMs);
+      }
+    }
+  });
+
+  it('respond の responseDelayMs は rng から決定される (PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: 0, max: 1, noNaN: true }),
+        (rngVal) => {
+          const config = makeConfig();
+          const logs = [userLog(), recentBotLog(20000)];
+          const action = decideBotAction(triggerRecord(), logs, config, now, () => rngVal);
+          if (action.type !== 'respond') return true;
+          return (
+            action.responseDelayMs >= config.responseDelayMinMs &&
+            action.responseDelayMs <= config.responseDelayMaxMs
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('実ユーザー数を N>=1 に増やしても respond の判定は変化しない (R5.2, PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 10 }),
+        (userCount) => {
+          const config = makeConfig();
+          const userLogs = Array.from({ length: userCount }, (_, i) => userLog(`user${i}`, 5000 + i * 100));
+          const logs = [...userLogs, recentBotLog(20000)];
+          const action = decideBotAction(triggerRecord(), logs, config, now, () => 0);
+          return action.type === 'respond';
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it('system 発言には respond しない (R3.5)', () => {
+    const logs = [userLog(), recentBotLog(20000)];
+    const sysRecord: TriggerRecord = {
+      ...triggerRecord(),
+      system: true,
+    };
+    const action = decideBotAction(sysRecord, logs, makeConfig(), now, () => 0);
+    expect(action.type).toBe('ignore');
+  });
+
+  it('kind:admin の発言には respond しない (R3.5)', () => {
+    const logs = [userLog(), recentBotLog(20000)];
+    const adminRecord: TriggerRecord = {
+      ...triggerRecord(),
+      metadata: { kind: 'admin' },
+    };
+    const action = decideBotAction(adminRecord, logs, makeConfig(), now, () => 0);
+    expect(action.type).toBe('ignore');
+  });
+
+  it('kind:fortune の発言には respond しない (R3.5)', () => {
+    const logs = [userLog(), recentBotLog(20000)];
+    const fortuneRecord: TriggerRecord = {
+      ...triggerRecord(),
+      metadata: { kind: 'fortune' },
+    };
+    const action = decideBotAction(fortuneRecord, logs, makeConfig(), now, () => 0);
+    expect(action.type).toBe('ignore');
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.room.test.ts
+++ b/supabase/functions/_shared/decideBotAction.room.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { decideBotAction, type TriggerRecord, type BotConfig } from './decideBotAction.ts';
+
+const now = 1_700_000_000_000;
+
+const defaultConfig: BotConfig = {
+  targetRoom: 'superbeginner',
+  greetings: ['こんにちは'],
+  cooldownMinMs: 8000,
+  cooldownMaxMs: 15000,
+  responseDelayMinMs: 2000,
+  responseDelayMaxMs: 6000,
+  historyMessageCap: 20,
+  botName: 'ゆいボット',
+  botColor: '#9b59b6',
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  systemPrompt: 'テスト',
+  webhookSecret: null,
+  openaiApiKey: 'sk-test',
+};
+
+function userLog() {
+  return {
+    uuid: 'u-alice',
+    name: 'alice',
+    color: '#ffffff',
+    message: 'hello',
+    time: now - 1000,
+  };
+}
+
+// Feature: chat-llm-bot, Property 7: 対象ルームスコープの不変条件
+// room_id !== 'superbeginner' は常に ignore('other-room') を返す (R3.4, R10.1, R10.2)
+describe('Property 7: 対象ルームスコープの不変条件', () => {
+  it('room_id が targetRoom でない場合 other-room を返す', () => {
+    const record: TriggerRecord = {
+      uuid: 'test',
+      room_id: 'other-room',
+      name: 'alice',
+      color: '#fff',
+      message: 'hello',
+      time: now - 1000,
+      metadata: { kind: 'normal' },
+    };
+    const action = decideBotAction(record, [userLog()], defaultConfig, now);
+    expect(action.type).toBe('ignore');
+    expect((action as { type: 'ignore'; reason: string }).reason).toBe('other-room');
+  });
+
+  it('room_id が undefined の場合 other-room を返す', () => {
+    const record: TriggerRecord = {
+      uuid: 'test',
+      name: 'alice',
+      color: '#fff',
+      message: 'hello',
+      time: now - 1000,
+    };
+    const action = decideBotAction(record, [userLog()], defaultConfig, now);
+    expect(action.type).toBe('ignore');
+    expect((action as { type: 'ignore'; reason: string }).reason).toBe('other-room');
+  });
+
+  it('任意の非対象ルームで常に other-room を返す (PBT)', () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => s !== defaultConfig.targetRoom),
+        fc.array(
+          fc.record({
+            uuid: fc.string({ minLength: 1 }),
+            name: fc.string({ minLength: 1, maxLength: 10 }),
+            color: fc.string(),
+            message: fc.string(),
+            time: fc.integer({ min: now - 5 * 60 * 1000, max: now }),
+          }),
+        ),
+        (roomId, recentLogs) => {
+          const record: TriggerRecord = {
+            uuid: 'test',
+            room_id: roomId,
+            name: 'alice',
+            color: '#fff',
+            message: 'hello',
+            time: now - 1000,
+            metadata: { kind: 'normal' },
+          };
+          const action = decideBotAction(record, recentLogs, defaultConfig, now);
+          return action.type === 'ignore' && (action as { reason: string }).reason === 'other-room';
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/supabase/functions/_shared/decideBotAction.ts
+++ b/supabase/functions/_shared/decideBotAction.ts
@@ -1,0 +1,86 @@
+import { getRecentParticipants, RECENT_WINDOW_MS, type ParticipantRow } from './participants.ts';
+import { buildHistory, type OpenAIMessage } from './buildHistory.ts';
+import type { BotConfig } from './botConfig.ts';
+
+export type { BotConfig } from './botConfig.ts';
+export type { OpenAIMessage } from './buildHistory.ts';
+export type { ParticipantRow as ChatRow } from './participants.ts';
+
+export type IgnoreReason =
+  | 'loop'         // kind==='bot': ループ防止 (R4.1)
+  | 'other-room'   // room_id !== targetRoom (R10.1)
+  | 'no-real-user' // 実ユーザー0人 (R3.6, R6.1)
+  | 'non-target'   // system/admin/fortune: 応答対象外 (R3.5)
+  | 'cooldown';    // クールダウン未経過 (R8.1)
+
+export type BotAction =
+  | { type: 'ignore'; reason: IgnoreReason }
+  | { type: 'greet'; messages: string[] }
+  | { type: 'respond'; responseDelayMs: number; history: OpenAIMessage[] };
+
+export type TriggerRecord = ParticipantRow & { room_id?: string };
+
+export function pickInRange(min: number, max: number, rng: () => number = Math.random): number {
+  if (max <= min) return min;
+  return Math.floor(min + rng() * (max - min));
+}
+
+export function lastBotMessageTime(logs: ParticipantRow[], now: number): number | null {
+  let latest: number | null = null;
+  for (const c of logs) {
+    if (c.metadata?.kind === 'bot' && now - c.time <= RECENT_WINDOW_MS) {
+      if (latest === null || c.time > latest) latest = c.time;
+    }
+  }
+  return latest;
+}
+
+/**
+ * 純粋な意思決定関数。I/O を持たず、入力のみから BotAction を決定する。
+ * 判定順序は設計書の①〜⑧に厳密に従う。
+ */
+export function decideBotAction(
+  record: TriggerRecord,
+  recentLogs: ParticipantRow[],
+  config: BotConfig,
+  now: number,
+  rng: () => number = Math.random,
+): BotAction {
+  // ① ループ防止(最優先) R4.1, R4.2, R11.3
+  if (record.metadata?.kind === 'bot') {
+    return { type: 'ignore', reason: 'loop' };
+  }
+
+  // ② ルーム限定(高コスト処理の前) R10.1, R10.2
+  if (record.room_id !== config.targetRoom) {
+    return { type: 'ignore', reason: 'other-room' };
+  }
+
+  // ④ 参加者判定 R3.6, R6.1, R6.3
+  const realUsers = getRecentParticipants(recentLogs, now);
+  if (realUsers.length === 0) {
+    return { type: 'ignore', reason: 'no-real-user' };
+  }
+
+  // ⑤ 冪等な登場: 直近5分に Bot 発言がなければ挨拶 R2.2, R2.3, R2.5
+  const latestBotTime = lastBotMessageTime(recentLogs, now);
+  if (latestBotTime === null) {
+    return { type: 'greet', messages: config.greetings }; // R2.4 連続投稿
+  }
+
+  // ③ 非対象メッセージは応答しない(登場評価は⑤で済み) R3.5
+  if (record.system || record.metadata?.kind === 'admin' || record.metadata?.kind === 'fortune') {
+    return { type: 'ignore', reason: 'non-target' };
+  }
+
+  // ⑥ クールダウン R8.1, R8.4, R8.7
+  const cooldownMs = pickInRange(config.cooldownMinMs, config.cooldownMaxMs, rng);
+  if (now - latestBotTime < cooldownMs) {
+    return { type: 'ignore', reason: 'cooldown' };
+  }
+
+  // ⑦+⑧ 応答プラン(実際の wait/OpenAI は呼び出し側) R8.2, R8.5, R8.6, R3.8
+  const responseDelayMs = pickInRange(config.responseDelayMinMs, config.responseDelayMaxMs, rng);
+  const history = buildHistory(recentLogs, config.historyMessageCap, now);
+  return { type: 'respond', responseDelayMs, history };
+}

--- a/supabase/functions/_shared/participants.ts
+++ b/supabase/functions/_shared/participants.ts
@@ -1,0 +1,56 @@
+// Deno 非依存の素の TypeScript。app 側 participants.ts と同一ロジック (R5.7)
+// 判定に必要なフィールドのみを受ける構造的型を使用し、app の Chat 型と互換。
+
+export const RECENT_WINDOW_MS = 5 * 60 * 1000;
+
+const WELCOME_PATTERN = /^(.+?)\sさん、Welcome to/;
+const EXIT_PATTERN = /^(.+?)さん、またきておくれやすぅ/;
+
+export type ParticipantRow = {
+  uuid: string;
+  name: string;
+  color: string;
+  message: string;
+  time: number;
+  system?: boolean;
+  metadata?: { kind?: string; userColor?: string } | null;
+};
+
+export type ParticipantEntry = {
+  uuid: string;
+  name: string;
+  color: string;
+};
+
+export function getRecentParticipants(
+  chatLog: ParticipantRow[],
+  now: number = Date.now(),
+): ParticipantEntry[] {
+  const map = new Map<string, ParticipantEntry>();
+  const recent = chatLog
+    .filter((c) => now - c.time <= RECENT_WINDOW_MS)
+    .slice()
+    .sort((a, b) => a.time - b.time);
+
+  for (const c of recent) {
+    if (c.metadata?.kind === 'bot') continue; // Bot は実ユーザーに数えない (R5.6)
+    if (c.metadata?.kind === 'admin') {
+      const enterMatch = c.message.match(WELCOME_PATTERN);
+      if (enterMatch) {
+        const name = enterMatch[1].trim();
+        const color = c.metadata.userColor ?? '#333333';
+        map.set(name, { uuid: c.uuid, name, color });
+        continue;
+      }
+      const exitMatch = c.message.match(EXIT_PATTERN);
+      if (exitMatch) {
+        map.delete(exitMatch[1].trim());
+        continue;
+      }
+    } else if (c.name && c.color && !c.system) {
+      map.set(c.name, { uuid: c.uuid, name: c.name, color: c.color });
+    }
+  }
+
+  return Array.from(map.values());
+}

--- a/supabase/functions/bot-respond/deno.json
+++ b/supabase/functions/bot-respond/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/bot-respond/index.ts
+++ b/supabase/functions/bot-respond/index.ts
@@ -1,0 +1,136 @@
+// Edge Function: bot-respond
+//
+// Supabase Database Webhook (pg_net) が chats テーブルへの INSERT を検知し、
+// このエンドポイントを非同期で HTTP 起動する。
+// Bot の発火判定・参加者判定・OpenAI 呼び出し・INSERT をすべてサーバー側で完結させる。
+// クライアントはこの関数を直接呼び出さない (R7.3)。
+//
+// デプロイ: supabase functions deploy bot-respond
+// 設定: config.toml で verify_jwt = false (Webhook はブラウザ経由でない)
+
+import { createClient } from '@supabase/supabase-js';
+import { decideBotAction, type TriggerRecord } from '../_shared/decideBotAction.ts';
+import { loadBotConfig, type BotConfig } from '../_shared/botConfig.ts';
+import type { OpenAIMessage } from '../_shared/buildHistory.ts';
+
+function verifyWebhookSecret(req: Request, secret: string | null): boolean {
+  if (!secret) return true;
+  return req.headers.get('x-bot-webhook-secret') === secret;
+}
+
+async function callOpenAI(
+  config: BotConfig,
+  history: OpenAIMessage[],
+): Promise<string> {
+  const messages: { role: string; content: string }[] = [
+    { role: 'system', content: config.systemPrompt },
+    ...history,
+  ];
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.openaiApiKey}`,
+    },
+    body: JSON.stringify({
+      model: config.model,
+      messages,
+      temperature: config.temperature,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OpenAI error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  const text = data?.choices?.[0]?.message?.content;
+  if (typeof text !== 'string' || !text) {
+    throw new Error('OpenAI: 空または不正な応答');
+  }
+  return text.trim();
+}
+
+async function insertBotMessages(
+  supabase: ReturnType<typeof createClient>,
+  config: BotConfig,
+  messages: string[],
+): Promise<void> {
+  for (const message of messages) {
+    const { error } = await supabase.from('chats').insert({
+      room_id: config.targetRoom,
+      name: config.botName,
+      color: config.botColor,
+      message,
+      system: false,
+      email: null,
+      metadata: { version: 1, kind: 'bot' },
+      ip: '',
+      ua: 'bot-respond',
+    });
+    if (error) console.error('bot-respond: INSERT failed:', error.message);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const config = loadBotConfig();
+
+  if (!verifyWebhookSecret(req, config.webhookSecret)) {
+    // 認証失敗でもリトライ嵐を防ぐため 200 を返す
+    return new Response('ok', { status: 200 });
+  }
+
+  try {
+    const payload = await req.json();
+    const record: TriggerRecord | undefined = payload?.record;
+    if (!record) return new Response('ok', { status: 200 });
+
+    // ①②をDBアクセス前に短絡(コスト最適化)
+    if (record.metadata?.kind === 'bot') return new Response('ok', { status: 200 });
+    if (record.room_id !== config.targetRoom) return new Response('ok', { status: 200 });
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+
+    const now = Date.now();
+    const since = now - 5 * 60 * 1000;
+    const { data: recentLogs } = await supabase
+      .from('chats')
+      .select('uuid,room_id,name,color,message,time,system,metadata')
+      .eq('room_id', config.targetRoom)
+      .eq('deleted', false)
+      .gte('time', since)
+      .order('time', { ascending: true });
+
+    const action = decideBotAction(record, recentLogs ?? [], config, now);
+
+    if (action.type === 'ignore') return new Response('ok', { status: 200 });
+
+    if (action.type === 'greet') {
+      await insertBotMessages(supabase, config, action.messages);
+      return new Response('ok', { status: 200 });
+    }
+
+    // action.type === 'respond'
+    await sleep(action.responseDelayMs);
+    const text = await callOpenAI(config, action.history);
+    await insertBotMessages(supabase, config, [text]);
+    return new Response('ok', { status: 200 });
+  } catch (err) {
+    // R9: 例外は握りつぶす。エラーメッセージは INSERT しない。常に 200。
+    console.error('bot-respond error (swallowed):', err);
+    return new Response('ok', { status: 200 });
+  }
+});

--- a/supabase/functions/bot-respond/index.ts
+++ b/supabase/functions/bot-respond/index.ts
@@ -14,7 +14,7 @@ import { loadBotConfig, type BotConfig } from '../_shared/botConfig.ts';
 import type { OpenAIMessage } from '../_shared/buildHistory.ts';
 
 function verifyWebhookSecret(req: Request, secret: string | null): boolean {
-  if (!secret) return true;
+  if (!secret) return false; // secret 未設定は安全側に倒す
   return req.headers.get('x-bot-webhook-secret') === secret;
 }
 
@@ -27,6 +27,8 @@ async function callOpenAI(
     ...history,
   ];
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 25_000);
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -38,7 +40,8 @@ async function callOpenAI(
       messages,
       temperature: config.temperature,
     }),
-  });
+    signal: controller.signal,
+  }).finally(() => clearTimeout(timeoutId));
 
   if (!res.ok) {
     throw new Error(`OpenAI error: ${res.status} ${res.statusText}`);
@@ -85,12 +88,20 @@ Deno.serve(async (req: Request) => {
   const config = loadBotConfig();
 
   if (!verifyWebhookSecret(req, config.webhookSecret)) {
-    // 認証失敗でもリトライ嵐を防ぐため 200 を返す
+    console.error('bot-respond: webhook secret missing or mismatch');
+    return new Response('ok', { status: 200 });
+  }
+
+  if (!config.openaiApiKey) {
+    console.error('bot-respond: OPENAI_API_KEY is not set');
     return new Response('ok', { status: 200 });
   }
 
   try {
     const payload = await req.json();
+    if (payload?.type !== 'INSERT' || payload?.table !== 'chats') {
+      return new Response('ok', { status: 200 });
+    }
     const record: TriggerRecord | undefined = payload?.record;
     if (!record) return new Response('ok', { status: 200 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
       './src/**/*.test.tsx',
       './src/**/*.spec.tsx',
       './src/**/*.spec.ts',
+      './supabase/functions/_shared/**/*.test.ts',
     ],
     exclude: ['node_modules', 'dist', '**/*.d.ts', 'src/vite-env.d.ts'],
     coverage: {


### PR DESCRIPTION
## 概要

Supabase Database Webhook 経由で起動する `bot-respond` Edge Function を追加し、`superbeginner` ルームにLLMチャットボットを実装しました。

- **OpenAI gpt-4o-mini** で応答生成。APIキーはサーバー側のみ保持（クライアント非公開）
- **Supabase Database Webhook** がトリガー → `bot-respond` Edge Function が判定・応答
- **ループ防止**: `metadata.kind: 'bot'` 付き投稿には応答しない (R11)
- **クールダウン制御**: 前回ボット発言から `cooldownMinMs`〜`cooldownMaxMs` が経過しないと応答しない
- **挨拶モード**: ルーム初回参加者への Welcome メッセージ検知で挨拶を返す
- **参加者フィルタ**: Bot は実ユーザー参加者にカウントしない (R5.6)

## 変更ファイル

### 新規

- `supabase/functions/bot-respond/` — Edge Function 本体 (Deno)
- `supabase/functions/_shared/` — 純粋関数群 (`decideBotAction`, `buildHistory`, `botConfig`, `participants`)
- `src/features/chat/utils/participants.ts` — React 非依存の純粋関数として切り出し
- `docs/bot-respond-deploy.md` — デプロイ手順チェックリスト
- 各種テストファイル (PBT: `fast-check` 採用)

### 変更

- `src/features/chat/types.ts` — `ChatMetadata.kind` に `'bot'` を追加
- `src/features/chat/utils/normalizeMetadata.ts` — `VALID_KINDS` をモジュールスコープに昇格、型安全化
- `src/features/chat/hooks/useParticipants.ts` — `participants.ts` 純粋関数のラッパーに変更
- `supabase/config.toml` — `[functions.bot-respond]` セクション追加 (`verify_jwt = false`)
- `vite.config.ts` — `_shared` テストを Vitest スキャン対象に追加

## アーキテクチャのポイント

- `decideBotAction` は I/O フリーな純粋関数として分離 → テスト容易性を確保
- `_shared/participants.ts` は `src/` 側と同一ロジックを複製（Deno バンドル境界を維持）
- 同等性は `participants.equivalence.test.ts` で担保
- `VALID_KINDS` を `Set<NonNullable<ChatMetadata['kind']>>` で型導出 → 型追加時に強制更新

## テスト計画

- [ ] `pnpm test` が全 145 件パスすること（済み）
- [ ] `supabase functions deploy bot-respond` 実行
- [ ] Supabase ダッシュボードで Database Webhook を `chats` テーブルの INSERT に設定
- [ ] `superbeginner` ルームでユーザーがメッセージを投稿 → ボットが数秒後に返答することを確認
- [ ] ボット自身の発言後にループが発生しないことを確認
- [ ] 環境変数 (`OPENAI_API_KEY`, `BOT_TARGET_ROOM` 等) を Supabase Secrets に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)